### PR TITLE
Dataset_batches

### DIFF
--- a/document_segmentation/model/dataset.py
+++ b/document_segmentation/model/dataset.py
@@ -82,8 +82,10 @@ class DocumentDataset(AbstractDataset):
 
         self._page_datasets: list[PageDataset] = page_datasets
 
-    def balance(self, max_size: int | None = None) -> AbstractDataset:
-        # FIXME: max_size is applied per document, not in total
+    def balance(self, max_size: Optional[int] = None) -> AbstractDataset:
+        # FIXME:
+        logging.warning("max_size is applied per document, not in total.")
+
         return self.__class__(
             [page_dataset.balance(max_size) for page_dataset in self._page_datasets]
         )

--- a/document_segmentation/model/dataset.py
+++ b/document_segmentation/model/dataset.py
@@ -78,10 +78,10 @@ class AbstractDataset(Dataset, abc.ABC):
 class DocumentDataset(AbstractDataset):
     """A dataset that wraps PageDatasets from different documents."""
 
-    def __init__(self, page_datasets: list["PageDataset"]) -> None:
+    def __init__(self, page_datasets: list["PageDataset"] = None) -> None:
         super().__init__()
 
-        self._page_datasets: list[PageDataset] = page_datasets
+        self._page_datasets: list[PageDataset] = page_datasets or []
 
     def __len__(self) -> int:
         return len(self._page_datasets)
@@ -182,7 +182,7 @@ class PageDataset(AbstractDataset):
     This Dataset implementation follows the logic of the models defined in document_segmentation.pagexml.model.
     """
 
-    def __init__(self, pages: list[Page]) -> None:
+    def __init__(self, pages: list[Page] = None) -> None:
         """Create a dataset from a list of pages.
 
         Args:
@@ -190,10 +190,13 @@ class PageDataset(AbstractDataset):
         """
         super().__init__()
 
-        self._pages = pages
+        self._pages = pages or []
 
     def __eq__(self, other):
         return self._pages == other._pages
+
+    def __add__(self, other: Dataset) -> "PageDataset":
+        return self.__class__(self._pages + other._pages)
 
     @property
     def pages(self) -> list[Page]:

--- a/document_segmentation/model/dataset.py
+++ b/document_segmentation/model/dataset.py
@@ -3,6 +3,7 @@ import logging
 import random
 from collections import Counter
 from itertools import islice
+from math import ceil
 from pathlib import Path
 from typing import Iterable, Optional, Union
 
@@ -120,7 +121,12 @@ class DocumentDataset(AbstractDataset):
             )
 
     def __len__(self) -> int:
-        return sum(len(page_dataset) for page_dataset in self._page_datasets)
+        return len(self._page_datasets)
+
+    def n_batches(self, batch_size: int) -> int:
+        return sum(
+            ceil(len(page_dataset) / batch_size) for page_dataset in self._page_datasets
+        )
 
     def __getitem__(self, index) -> Page:
         i = 0

--- a/document_segmentation/model/dataset.py
+++ b/document_segmentation/model/dataset.py
@@ -83,6 +83,15 @@ class DocumentDataset(AbstractDataset):
 
         self._page_datasets: list[PageDataset] = page_datasets
 
+    def __len__(self) -> int:
+        return len(self._page_datasets)
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, self.__class__)
+            and self._page_datasets == other._page_datasets
+        )
+
     def balance(self, max_size: Optional[int] = None) -> AbstractDataset:
         # FIXME:
         logging.warning("max_size is applied per document, not in total.")
@@ -119,9 +128,6 @@ class DocumentDataset(AbstractDataset):
             yield from dataset.remove_short_regions(min_region_length).batches(
                 batch_size
             )
-
-    def __len__(self) -> int:
-        return len(self._page_datasets)
 
     def n_batches(self, batch_size: int) -> int:
         return sum(

--- a/document_segmentation/model/dataset.py
+++ b/document_segmentation/model/dataset.py
@@ -92,6 +92,12 @@ class DocumentDataset(AbstractDataset):
             and self._page_datasets == other._page_datasets
         )
 
+    def __getitem__(self, index) -> Page:
+        if isinstance(index, slice):
+            return self.__class__(self._page_datasets[index])
+        else:
+            return self._page_datasets[index]
+
     def balance(self, max_size: Optional[int] = None) -> AbstractDataset:
         # FIXME:
         logging.warning("max_size is applied per document, not in total.")
@@ -133,15 +139,6 @@ class DocumentDataset(AbstractDataset):
         return sum(
             ceil(len(page_dataset) / batch_size) for page_dataset in self._page_datasets
         )
-
-    def __getitem__(self, index) -> Page:
-        i = 0
-        for page_dataset in self._page_datasets:
-            if i + len(page_dataset) > index:
-                return page_dataset[index - i]
-            i += len(page_dataset)
-
-        raise IndexError(f"Index {index} out of range.")
 
     def split(self, portion: float) -> tuple["DocumentDataset", "DocumentDataset"]:
         split = int(len(self._page_datasets) * portion)

--- a/document_segmentation/model/page_sequence_tagger.py
+++ b/document_segmentation/model/page_sequence_tagger.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Optional
 
 import torch
@@ -89,10 +90,10 @@ class PageSequenceTagger(nn.Module, DeviceModule):
                 loss.backward()
                 optimizer.step()
             if self._device == "mps":
-                tqdm.write(
+                logging.debug(
                     f"Current allocated memory (MPS): {torch.mps.current_allocated_memory() / 1024 ** 2:.0f} MB"
                 )
-                tqdm.write(
+                logging.debug(
                     f"Driver allocated memory (MPS): {torch.mps.driver_allocated_memory() / 1024 ** 2:.0f} MB"
                 )
 

--- a/document_segmentation/model/page_sequence_tagger.py
+++ b/document_segmentation/model/page_sequence_tagger.py
@@ -78,7 +78,7 @@ class PageSequenceTagger(nn.Module, DeviceModule):
             for batch in tqdm(
                 dataset.batches(batch_size),
                 unit="batch",
-                total=len(dataset) / batch_size,  # FIXME
+                total=dataset.n_batches(batch_size),
             ):
                 optimizer.zero_grad()
                 outputs = self(batch).to(self._device)

--- a/document_segmentation/model/page_sequence_tagger.py
+++ b/document_segmentation/model/page_sequence_tagger.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from ..pagexml.datamodel.label import Label
 from ..settings import PAGE_SEQUENCE_TAGGER_RNN_CONFIG
-from .dataset import PageDataset
+from .dataset import DocumentDataset, PageDataset
 from .device_module import DeviceModule
 from .page_embedding import PageEmbedding
 
@@ -61,15 +61,13 @@ class PageSequenceTagger(nn.Module, DeviceModule):
 
     def train_(
         self,
-        pages: PageDataset,
+        dataset: DocumentDataset,
         epochs: int = 3,
         batch_size: int = _DEFAULT_BATCH_SIZE,
         weights: Optional[torch.Tensor] = None,
     ):
         self.train()
 
-        if weights is None:
-            weights = pages.class_weights()
         if len(weights) != len(Label):
             raise ValueError(f"Expected {len(Label)} weights, got {len(weights)}.")
 
@@ -78,7 +76,9 @@ class PageSequenceTagger(nn.Module, DeviceModule):
 
         for _ in range(epochs):
             for batch in tqdm(
-                pages.batches(batch_size), unit="batch", total=len(pages) / batch_size
+                dataset.batches(batch_size),
+                unit="batch",
+                total=len(dataset) / batch_size,  # FIXME
             ):
                 optimizer.zero_grad()
                 outputs = self(batch).to(self._device)

--- a/notebooks/page_sequence_tagger_generale_missiven.ipynb
+++ b/notebooks/page_sequence_tagger_generale_missiven.ipynb
@@ -31,14 +31,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents:  12%|█▏        | 114/914 [04:00<30:03,  2.25s/doc] "
+      "Writing documents:   0%|          | 0/368 [00:00<?, ?doc/s]"
      ]
     },
     {
@@ -52,63 +52,37 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents:  36%|███▋      | 332/914 [14:04<17:26,  1.80s/doc]  "
+      "Writing documents:  11%|█         | 40/368 [01:08<11:20,  2.08s/doc]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Skipping inventory '1684' due to error: 404 Client Error: Not Found for url: https://hucdrive.huc.knaw.nl/HTR/obp-v2-pagexml-leon-metadata-trimmed-2023-11/1684.zip\n"
+      "Skipping row with inventory number 2770 due to reason: 'Niet gedigitaliseerd.'\n",
+      "Skipping row with inventory number 2770 due to reason: 'Niet gedigitaliseerd.'\n",
+      "Skipping row with inventory number 2770 due to reason: 'Niet gedigitaliseerd.'\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents:  36%|███▋      | 333/914 [14:05<14:28,  1.50s/doc]"
+      "Writing documents:  17%|█▋        | 61/368 [01:59<14:40,  2.87s/doc]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Skipping inventory '1684' due to error: 404 Client Error: Not Found for url: https://hucdrive.huc.knaw.nl/HTR/obp-v2-pagexml-leon-metadata-trimmed-2023-11/1684.zip\n"
+      "Skipping row with inventory number 2911 due to reason: 'Niet gedigitaliseerd.'\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents:  37%|███▋      | 334/914 [14:05<12:00,  1.24s/doc]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Skipping inventory '1684' due to error: 404 Client Error: Not Found for url: https://hucdrive.huc.knaw.nl/HTR/obp-v2-pagexml-leon-metadata-trimmed-2023-11/1684.zip\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Writing documents:  42%|████▏     | 386/914 [17:16<30:44,  3.49s/doc]  "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Skipping inventory '1887' due to error: 404 Client Error: Not Found for url: https://hucdrive.huc.knaw.nl/HTR/obp-v2-pagexml-leon-metadata-trimmed-2023-11/1887.zip\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Writing documents:  44%|████▍     | 405/914 [18:37<32:50,  3.87s/doc]"
+      "Writing documents:  99%|█████████▊| 363/368 [17:14<00:14,  2.85s/doc]\n"
      ]
     }
    ],
@@ -180,17 +154,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Reading JSON files:  21%|██▏       | 194/909 [00:15<00:21, 33.03file/s]WARNING:root:No pages found in document id='352' inventory_nr=1684 inventory_part=None pages=[].\n",
-      "Reading JSON files:  68%|██████▊   | 614/909 [00:56<00:16, 17.92file/s]WARNING:root:No pages found in document id='412' inventory_nr=1887 inventory_part=None pages=[].\n",
-      "Reading JSON files:  68%|██████▊   | 620/909 [00:56<00:15, 18.13file/s]WARNING:root:No pages found in document id='353' inventory_nr=1684 inventory_part=None pages=[].\n",
-      "Reading JSON files:  96%|█████████▌| 869/909 [01:20<00:04,  9.60file/s]WARNING:root:No pages found in document id='354' inventory_nr=1684 inventory_part=None pages=[].\n",
-      "Reading JSON files: 100%|██████████| 909/909 [01:25<00:00, 10.65file/s]\n"
+      "Reading JSON files: 100%|██████████| 909/909 [01:40<00:00,  9.07file/s]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "191146"
+       "909"
       ]
      },
      "execution_count": 6,
@@ -199,12 +169,11 @@
     }
    ],
    "source": [
-    "from document_segmentation.model.dataset import PageDataset\n",
-    "from document_segmentation.settings import MIN_REGION_TEXT_LENGTH\n",
+    "from document_segmentation.model.dataset import DocumentDataset\n",
     "\n",
-    "dataset = PageDataset.from_dir(GENERALE_MISSIVEN_DOCUMENT_DIR).remove_short_regions(\n",
-    "    MIN_REGION_TEXT_LENGTH\n",
-    ")\n",
+    "dataset = DocumentDataset.from_dir(GENERALE_MISSIVEN_DOCUMENT_DIR)\n",
+    "dataset.shuffle()\n",
+    "\n",
     "len(dataset)"
    ]
   },
@@ -216,7 +185,7 @@
     {
      "data": {
       "text/plain": [
-       "Counter({<Label.IN: 2>: 189343, <Label.BEGIN: 1>: 905, <Label.END: 3>: 898})"
+       "Counter({<Label.IN: 1>: 189343, <Label.BEGIN: 0>: 905, <Label.END: 2>: 898})"
       ]
      },
      "execution_count": 7,
@@ -236,7 +205,7 @@
     {
      "data": {
       "text/plain": [
-       "[210.97792494481237, 1.0095170694608755, 212.6206896551724, 191146.0]"
+       "[1.0033112582781456, 0.004800785871218523, 1.0111234705228032, 909.0]"
       ]
      },
      "execution_count": 8,
@@ -250,45 +219,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Page(label=<Label.IN: 2>, regions=[Region(id='region_ae02e415-afa1-48f8-aeef-2ad2960df7fc_8', types=(<RegionType.TEXT_REGION: 'text_region'>, <RegionType.MARGINALIA: 'marginalia'>, <RegionType.PHYSICAL_STRUCTURE_DOC: 'physical_structure_doc'>, <RegionType.PAGEXML_DOC: 'pagexml_doc'>), coordinates=((451, 882), (455, 886), (455, 907), (460, 911), (460, 915), (468, 923), (468, 927), (472, 927), (480, 936), (501, 936), (505, 940), (551, 940), (555, 936), (580, 936), (584, 931), (613, 931), (617, 927), (675, 927), (679, 931), (725, 931), (729, 936), (870, 936), (874, 931), (886, 931), (894, 923), (899, 923), (907, 915), (911, 915), (915, 911), (923, 911), (927, 907), (940, 907), (944, 902), (948, 902), (956, 894), (961, 894), (965, 890), (977, 890), (981, 886), (998, 886), (1002, 882), (1027, 882), (1031, 878), (1048, 878), (1056, 869), (1060, 869), (1060, 861), (1064, 857), (1064, 844), (1068, 840), (1068, 828), (1072, 824), (1072, 820), (1077, 816), (1077, 807), (1081, 803), (1081, 766), (1077, 762), (1077, 753), (1068, 745), (1064, 745), (1060, 741), (1056, 741), (1052, 737), (1043, 737), (1039, 733), (1027, 733), (1023, 729), (1006, 729), (1002, 724), (969, 724), (965, 720), (961, 720), (956, 716), (952, 716), (948, 712), (787, 712), (783, 708), (683, 708), (679, 704), (650, 704), (646, 700), (613, 700), (609, 695), (518, 695), (513, 700), (509, 700), (505, 704), (501, 704), (497, 708), (493, 708), (480, 720), (480, 724), (472, 733), (472, 741), (468, 745), (468, 749), (464, 753), (464, 762), (460, 766), (460, 807), (455, 811), (455, 840), (451, 844)), lines=(\"die voor 's Comp:s pant„\", 'verdeet zyn')), Region(id='region_75d25d3b-558b-476b-b1d6-459054620de2_7', types=(<RegionType.TEXT_REGION: 'text_region'>, <RegionType.MARGINALIA: 'marginalia'>, <RegionType.PHYSICAL_STRUCTURE_DOC: 'physical_structure_doc'>, <RegionType.PAGEXML_DOC: 'pagexml_doc'>), coordinates=((435, 2438), (435, 2480), (431, 2484), (431, 2496), (435, 2500), (435, 2517), (439, 2521), (439, 2600), (443, 2604), (443, 2612), (451, 2620), (451, 2625), (455, 2625), (460, 2629), (464, 2629), (468, 2633), (476, 2633), (480, 2637), (489, 2637), (493, 2641), (497, 2641), (501, 2645), (513, 2645), (518, 2649), (547, 2649), (551, 2645), (571, 2645), (576, 2641), (605, 2641), (609, 2637), (638, 2637), (642, 2633), (741, 2633), (745, 2629), (762, 2629), (766, 2625), (803, 2625), (807, 2620), (812, 2620), (816, 2616), (828, 2616), (832, 2612), (841, 2612), (845, 2608), (861, 2608), (865, 2604), (874, 2604), (878, 2600), (890, 2600), (894, 2596), (907, 2596), (911, 2591), (927, 2591), (932, 2596), (936, 2596), (940, 2591), (952, 2591), (956, 2587), (965, 2587), (969, 2583), (1019, 2583), (1023, 2579), (1039, 2579), (1043, 2575), (1048, 2575), (1056, 2567), (1060, 2567), (1068, 2558), (1077, 2558), (1081, 2554), (1081, 2546), (1085, 2542), (1085, 2525), (1089, 2521), (1089, 2496), (1085, 2492), (1085, 2488), (1081, 2484), (1081, 2480), (1077, 2476), (1077, 2430), (1072, 2426), (1072, 2422), (1056, 2405), (1014, 2405), (1010, 2401), (961, 2401), (956, 2397), (936, 2397), (932, 2393), (899, 2393), (894, 2389), (849, 2389), (845, 2393), (836, 2393), (832, 2389), (762, 2389), (758, 2384), (497, 2384), (493, 2389), (489, 2389), (484, 2393), (480, 2393), (476, 2397), (472, 2397), (468, 2401), (464, 2401), (460, 2405), (455, 2405), (451, 2409), (451, 2413), (443, 2422), (443, 2426), (439, 2430), (439, 2434)), lines=('omwelke reden 3.', 'pantchiallangs vrogt', 'werden')), Region(id='region_2377d1f8-5576-4090-867e-f0faa2aa830a_6', types=(<RegionType.TEXT_REGION: 'text_region'>, <RegionType.MARGINALIA: 'marginalia'>, <RegionType.PHYSICAL_STRUCTURE_DOC: 'physical_structure_doc'>, <RegionType.PAGEXML_DOC: 'pagexml_doc'>), coordinates=((2770, 3328), (2770, 3415), (2774, 3419), (2774, 3440), (2778, 3444), (2778, 3448), (2782, 3452), (2787, 3452), (2799, 3465), (2803, 3465), (2807, 3469), (2828, 3469), (2832, 3473), (2869, 3473), (2874, 3477), (2944, 3477), (2948, 3473), (2994, 3473), (2998, 3469), (3018, 3469), (3023, 3465), (3068, 3465), (3072, 3461), (3089, 3461), (3093, 3457), (3110, 3457), (3114, 3452), (3126, 3452), (3130, 3448), (3139, 3448), (3147, 3440), (3151, 3440), (3155, 3436), (3163, 3436), (3168, 3432), (3192, 3432), (3197, 3428), (3205, 3428), (3209, 3423), (3213, 3423), (3217, 3419), (3234, 3419), (3238, 3415), (3267, 3415), (3271, 3411), (3296, 3411), (3300, 3407), (3312, 3407), (3317, 3403), (3333, 3403), (3337, 3399), (3346, 3399), (3350, 3395), (3358, 3395), (3362, 3390), (3370, 3390), (3370, 3328), (3366, 3324), (3362, 3324), (3354, 3316), (3350, 3316), (3333, 3299), (3325, 3299), (3321, 3295), (3317, 3295), (3308, 3287), (3300, 3287), (3296, 3283), (3283, 3283), (3279, 3279), (3271, 3279), (3267, 3274), (3255, 3274), (3250, 3270), (3230, 3270), (3226, 3266), (3209, 3266), (3205, 3262), (3192, 3262), (3188, 3258), (3172, 3258), (3168, 3254), (3155, 3254), (3151, 3250), (2969, 3250), (2965, 3254), (2936, 3254), (2932, 3258), (2919, 3258), (2915, 3262), (2898, 3262), (2894, 3266), (2882, 3266), (2878, 3270), (2861, 3270), (2857, 3274), (2840, 3274), (2836, 3279), (2824, 3279), (2820, 3283), (2816, 3283), (2811, 3287), (2807, 3287), (2778, 3316), (2778, 3320)), lines=('maer de Z: O:t Eijlanden', 'vertrocken')), Region(id='region_215df0f8-00e7-4681-8390-54192d275218_1', types=(<RegionType.TEXT_REGION: 'text_region'>, <RegionType.PHYSICAL_STRUCTURE_DOC: 'physical_structure_doc'>, <RegionType.PARAGRAPH: 'paragraph'>, <RegionType.PAGEXML_DOC: 'pagexml_doc'>), coordinates=((2774, 592), (2720, 588), (2592, 609), (2261, 604), (1979, 617), (1793, 617), (1648, 604), (1246, 613), (1192, 604), (1126, 638), (1118, 687), (1122, 700), (1114, 716), (1077, 749), (1085, 766), (1085, 803), (1064, 861), (1085, 915), (1081, 956), (1101, 1076), (1106, 1151), (1139, 1279), (1135, 1441), (1143, 1478), (1143, 1697), (1130, 1784), (1135, 1991), (1122, 2120), (1126, 2277), (1093, 2405), (1101, 2480), (1093, 2492), (1085, 2546), (1097, 2600), (1093, 2687), (1110, 2803), (1126, 3154), (1139, 3217), (1135, 3403), (1101, 3560), (1106, 3589), (1118, 3606), (1164, 3622), (1213, 3622), (1263, 3610), (1337, 3606), (1495, 3614), (2352, 3614), (2414, 3606), (2588, 3601), (2642, 3614), (2708, 3643), (2737, 3639), (2766, 3614), (2782, 3573), (2774, 3444), (2766, 3415), (2766, 3266), (2778, 3159), (2762, 3039), (2766, 2774), (2749, 2654), (2753, 2492), (2745, 2447), (2741, 2273), (2758, 2198), (2766, 1962), (2758, 1896), (2753, 1143), (2762, 1068), (2758, 907), (2799, 695), (2795, 625)), lines=('Pantchiallang niet bang waren', '„chiallang niet de„ maar deselve kunnende magt', 'werden wel wat anders zoud', 'doen tot wraak over het nem', 'van Een hunner vaartuijgen', \"onder 't Eijland Wokam in den\", \"voorleden Iare 't geen de minist\", 'heeft gepermoveert om bij voorn', 'briev van den 15„en aug:s in plaats', 'van de pantchiallangs Nova', 'hollandia, Lethij, en de voorn,', 'alsoo de eerste in den voorleden', 'Jaare afgelopen en verbrand', 'de tweede vermist is, en de derd', 'werden om 3. nieuwe niet')), Region(id='region_963c3538-4b10-4988-aaa6-46b65c8d3440_2', types=(<RegionType.TEXT_REGION: 'text_region'>, <RegionType.PHYSICAL_STRUCTURE_DOC: 'physical_structure_doc'>, <RegionType.PARAGRAPH: 'paragraph'>, <RegionType.PAGEXML_DOC: 'pagexml_doc'>), coordinates=((5064, 567), (5023, 563), (4882, 604), (4782, 617), (4563, 596), (3731, 604), (3470, 617), (3424, 629), (3399, 650), (3399, 758), (3387, 861), (3395, 882), (3395, 1051), (3416, 1283), (3416, 1706), (3404, 1888), (3412, 2774), (3391, 2935), (3391, 3179), (3412, 3233), (3412, 3274), (3375, 3328), (3375, 3395), (3408, 3440), (3391, 3515), (3391, 3577), (3428, 3614), (3495, 3626), (3602, 3610), (4811, 3601), (5085, 3618), (5118, 3597), (5130, 3552), (5122, 3254), (5101, 3167), (5089, 2972), (5056, 2931), (4890, 2939), (4816, 2923), (4646, 2914), (4045, 2931), (3710, 2902), (3611, 2914), (3569, 2889), (3573, 2869), (3598, 2852), (3822, 2860), (3946, 2819), (3979, 2790), (3971, 2728), (3987, 2691), (4008, 2670), (4066, 2654), (4174, 2645), (4493, 2654), (4571, 2645), (4956, 2649), (5047, 2637), (5081, 2616), (5097, 2567), (5093, 2418), (5101, 2393), (5089, 2074), (5105, 1718), (5105, 1022), (5085, 886), (5089, 609)), lines=('alleen aan ons versoek, maar', 'ook een voorslag tedoen, ten', 'Eijnde in plaatse van een, drie', 'wel bemande pantchiallangs', 'op die swervers uijt tesenden,', 'en des mogelijk te overmeesteren', 'dan wel van daar te verjagen', 'waar op men bij het houden der', 'besoignes de nodige reflexie', 'zal nemen en den Eijsch dier', 'vaartuijgen naar vermogen', 'voldoen.', \"Voorts was op den 17:' maart\", 'deses Iaars om de posthouders', 'nodige naar usantie te voorsten', 'door ouderdom staat afgelegt te zijn gecommitteerd:s op de Z: O„ter Eijlanden van het'))], scan_nr=57, doc_id='NL-HaNA_1.04.02_2113_0057.jpg')"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dataset[5000]"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Counter({<Label.IN: 2>: 151442, <Label.BEGIN: 1>: 740, <Label.END: 3>: 734})"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "split = int(len(dataset) * TRAINING_DATA)\n",
-    "\n",
-    "training_data = dataset[:split]\n",
-    "training_data._class_counts()"
+    "training_data, test_data = dataset.split(TRAINING_DATA)"
    ]
   },
   {
@@ -299,7 +234,7 @@
     {
      "data": {
       "text/plain": [
-       "Counter({<Label.IN: 2>: 37901, <Label.BEGIN: 1>: 165, <Label.END: 3>: 164})"
+       "Counter({<Label.IN: 1>: 154381, <Label.BEGIN: 0>: 724, <Label.END: 2>: 717})"
       ]
      },
      "execution_count": 11,
@@ -308,7 +243,26 @@
     }
    ],
    "source": [
-    "test_data = dataset[split:]\n",
+    "training_data._class_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({<Label.IN: 1>: 34962, <Label.BEGIN: 0>: 181, <Label.END: 2>: 181})"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "test_data._class_counts()"
    ]
   },
@@ -321,20 +275,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
     "\n",
-    "BATCH_SIZE = 32\n",
+    "BATCH_SIZE = 64\n",
     "EPOCHS = 3\n",
     "WEIGHTS = torch.Tensor(dataset.class_weights())  # For an imbalanced dataset"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,18 +297,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/carstens/workspace/.venv/lib/python3.10/site-packages/torch/nn/modules/rnn.py:83: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.1 and num_layers=1\n",
-      "  warnings.warn(\"dropout option adds dropout after all but last \"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from document_segmentation.model.page_sequence_tagger import PageSequenceTagger\n",
     "\n",
@@ -363,16 +308,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'cuda'"
+       "'mps'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -397,18 +342,18 @@
        "        (1): Pooling({'word_embedding_dimension': 768, 'pooling_mode_cls_token': False, 'pooling_mode_mean_tokens': True, 'pooling_mode_max_tokens': False, 'pooling_mode_mean_sqrt_len_tokens': False, 'pooling_mode_weightedmean_tokens': False, 'pooling_mode_lasttoken': False})\n",
        "      )\n",
        "      (_region_type): Embedding(9, 16)\n",
-       "      (_linear): Linear(in_features=784, out_features=128, bias=True)\n",
+       "      (_linear): Linear(in_features=784, out_features=512, bias=True)\n",
        "    )\n",
-       "    (_rnn): LSTM(128, 128, batch_first=True, dropout=0.1, bidirectional=True)\n",
-       "    (_linear): Linear(in_features=256, out_features=128, bias=True)\n",
+       "    (_rnn): LSTM(512, 256, num_layers=2, batch_first=True, dropout=0.1, bidirectional=True)\n",
+       "    (_linear): Linear(in_features=512, out_features=256, bias=True)\n",
        "  )\n",
-       "  (_rnn): LSTM(128, 64, batch_first=True, dropout=0.1, bidirectional=True)\n",
-       "  (_linear): Linear(in_features=128, out_features=4, bias=True)\n",
+       "  (_rnn): LSTM(256, 256, num_layers=2, batch_first=True, dropout=0.1, bidirectional=True)\n",
+       "  (_linear): Linear(in_features=512, out_features=4, bias=True)\n",
        "  (_softmax): Softmax(dim=1)\n",
        ")"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -419,56 +364,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "313batch [06:34,  1.26s/batch]                        \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Loss:\t1.624]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "313batch [00:14, 21.18batch/s]                        \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Loss:\t1.557]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "313batch [00:14, 21.03batch/s]                        "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Loss:\t1.580]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      " 50%|████▉     | 1439/2888 [1:18:47<43:42,  1.81s/batch]  "
      ]
     }
    ],
@@ -485,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1947,7 +1850,7 @@
     "f1_score = MulticlassF1Score(average=None, num_classes=len(Label))\n",
     "\n",
     "for batch in tqdm(\n",
-    "    test_data.batches(BATCH_SIZE), total=len(test_data) / BATCH_SIZE, unit=\"batch\"\n",
+    "    test_data.batches(BATCH_SIZE), total=test_data.n_batches(BATCH_SIZE), unit=\"batch\"\n",
     "):\n",
     "    predicted = tagger(batch)\n",
     "    labels = batch.labels()\n",
@@ -1974,7 +1877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/notebooks/page_sequence_tagger_renate.ipynb
+++ b/notebooks/page_sequence_tagger_renate.ipynb
@@ -74,21 +74,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents: 0doc [00:00, ?doc/s]"
+      "Writing documents:   0%|          | 0/26 [00:00<?, ?doc/s]"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents: 26doc [00:09,  2.66doc/s]\n"
+      "Writing documents: 100%|██████████| 26/26 [00:10<00:00,  2.55doc/s]\n"
      ]
     }
    ],
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,14 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Reading JSON files: 100%|██████████| 104/104 [00:00<00:00, 176.14file/s]\n"
+      "Reading JSON files: 100%|██████████| 104/104 [00:00<00:00, 176.63file/s]\n"
      ]
     },
     {
@@ -161,24 +161,21 @@
        "2184"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from document_segmentation.model.dataset import PageDataset\n",
-    "from document_segmentation.settings import MIN_REGION_TEXT_LENGTH\n",
+    "from document_segmentation.model.dataset import DocumentDataset\n",
     "\n",
-    "dataset = PageDataset.from_dir(RENATE_ANALYSIS_DIR).remove_short_regions(\n",
-    "    MIN_REGION_TEXT_LENGTH\n",
-    ")\n",
+    "dataset: DocumentDataset = DocumentDataset.from_dir(RENATE_ANALYSIS_DIR)\n",
     "len(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +187,7 @@
        "         <Label.OUT: 3>: 73})"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -210,7 +207,7 @@
        "[20.8, 1.1446540880503144, 21.623762376237625, 29.513513513513512]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -221,51 +218,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data, test_data = dataset.split(TRAINING_DATA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({<Label.IN: 1>: 1533,\n",
-       "         <Label.BEGIN: 0>: 77,\n",
-       "         <Label.END: 2>: 75,\n",
-       "         <Label.OUT: 3>: 62})"
+       "Counter({<Label.IN: 1>: 1591,\n",
+       "         <Label.BEGIN: 0>: 83,\n",
+       "         <Label.END: 2>: 81,\n",
+       "         <Label.OUT: 3>: 67})"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "split = int(len(dataset) * TRAINING_DATA)\n",
-    "\n",
-    "training_data = dataset[:split]\n",
     "training_data._class_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({<Label.IN: 1>: 374,\n",
-       "         <Label.BEGIN: 0>: 27,\n",
-       "         <Label.END: 2>: 25,\n",
-       "         <Label.OUT: 3>: 11})"
+       "Counter({<Label.IN: 1>: 316,\n",
+       "         <Label.BEGIN: 0>: 21,\n",
+       "         <Label.END: 2>: 19,\n",
+       "         <Label.OUT: 3>: 6})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "test_data = dataset[split:]\n",
     "test_data._class_counts()"
    ]
   },
@@ -278,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -320,7 +322,7 @@
        "'mps'"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -351,11 +353,12 @@
        "    (_linear): Linear(in_features=512, out_features=256, bias=True)\n",
        "  )\n",
        "  (_rnn): LSTM(256, 256, num_layers=2, batch_first=True, dropout=0.1, bidirectional=True)\n",
-       "  (crf): CRF(num_tags=4)\n",
+       "  (_linear): Linear(in_features=512, out_features=4, bias=True)\n",
+       "  (_softmax): Softmax(dim=1)\n",
        ")"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,31 +369,179 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/54.59375 [00:01<?, ?batch/s]\n"
+      "\n",
+      "/Users/carstenschnober/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/tqdm/std.py:636: TqdmWarning: clamping frac to range [0, 1]\n",
+      "116batch [01:44,  1.11batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:17<?, ?file/s]"
      ]
     },
     {
-     "ename": "TypeError",
-     "evalue": "CRF.forward() missing 1 required positional argument: 'tags'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[28], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mtagger\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtrain_\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtraining_data\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEPOCHS\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mBATCH_SIZE\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mWEIGHTS\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mto\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtagger\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_device\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/document_segmentation/model/page_sequence_tagger.py:80\u001b[0m, in \u001b[0;36mPageSequenceTagger.train_\u001b[0;34m(self, pages, epochs, batch_size, weights)\u001b[0m\n\u001b[1;32m     76\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m batch \u001b[38;5;129;01min\u001b[39;00m tqdm(\n\u001b[1;32m     77\u001b[0m     pages\u001b[38;5;241m.\u001b[39mbatches(batch_size), unit\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbatch\u001b[39m\u001b[38;5;124m\"\u001b[39m, total\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mlen\u001b[39m(pages) \u001b[38;5;241m/\u001b[39m batch_size\n\u001b[1;32m     78\u001b[0m ):\n\u001b[1;32m     79\u001b[0m     optimizer\u001b[38;5;241m.\u001b[39mzero_grad()\n\u001b[0;32m---> 80\u001b[0m     outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mbatch\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mto(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_device)\n\u001b[1;32m     81\u001b[0m     \u001b[38;5;66;03m# loss = criterion(outputs, batch.label_tensor().to(self._device)).to(\u001b[39;00m\n\u001b[1;32m     82\u001b[0m     \u001b[38;5;66;03m#     self._device\u001b[39;00m\n\u001b[1;32m     83\u001b[0m     \u001b[38;5;66;03m# )\u001b[39;00m\n\u001b[1;32m     84\u001b[0m     loss \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m-\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcrf(outputs, batch\u001b[38;5;241m.\u001b[39mlabel_tensor()\u001b[38;5;241m.\u001b[39mto(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_device))\n",
-      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1511\u001b[0m, in \u001b[0;36mModule._wrapped_call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1509\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_compiled_call_impl(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)  \u001b[38;5;66;03m# type: ignore[misc]\u001b[39;00m\n\u001b[1;32m   1510\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 1511\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_call_impl\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1520\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1515\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1518\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1519\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1520\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1522\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   1523\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n",
-      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/document_segmentation/model/page_sequence_tagger.py:48\u001b[0m, in \u001b[0;36mPageSequenceTagger.forward\u001b[0;34m(self, pages)\u001b[0m\n\u001b[1;32m     42\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m page_embeddings\u001b[38;5;241m.\u001b[39msize() \u001b[38;5;241m==\u001b[39m (\n\u001b[1;32m     43\u001b[0m     \u001b[38;5;28mlen\u001b[39m(pages),\n\u001b[1;32m     44\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_page_embedding\u001b[38;5;241m.\u001b[39moutput_size,\n\u001b[1;32m     45\u001b[0m ), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBad shape: \u001b[39m\u001b[38;5;124m{\u001b[39m\u001b[38;5;124mpages.size()}\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     47\u001b[0m rnn_out, hidden \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_rnn(page_embeddings)\n\u001b[0;32m---> 48\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcrf\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrnn_out\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     50\u001b[0m output \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_linear(rnn_out)\n\u001b[1;32m     51\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m output\u001b[38;5;241m.\u001b[39msize() \u001b[38;5;241m==\u001b[39m (\u001b[38;5;28mlen\u001b[39m(pages), \u001b[38;5;28mlen\u001b[39m(Label)), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBad shape: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moutput\u001b[38;5;241m.\u001b[39msize()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
-      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1511\u001b[0m, in \u001b[0;36mModule._wrapped_call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1509\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_compiled_call_impl(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)  \u001b[38;5;66;03m# type: ignore[misc]\u001b[39;00m\n\u001b[1;32m   1510\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 1511\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_call_impl\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1520\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1515\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1518\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1519\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1520\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1522\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   1523\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n",
-      "\u001b[0;31mTypeError\u001b[0m: CRF.forward() missing 1 required positional argument: 'tags'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2906 MB\n",
+      "[Loss:\t6.392]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:06, 18.18batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:23<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2860 MB\n",
+      "[Loss:\t4.474]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:06, 18.00batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:30<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t4.442]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:06, 19.33batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:36<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t4.433]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:05, 19.72batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:41<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t4.131]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:05, 19.71batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:47<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t3.584]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:05, 19.84batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:53<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t3.574]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:05, 19.80batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [09:59<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t3.569]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:05, 19.60batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [10:05<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t3.568]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "116batch [00:05, 19.56batch/s]\n",
+      "Reading JSON files:   0%|          | 0/104 [10:11<?, ?file/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current allocated memory (MPS): 1182 MB\n",
+      "Driver allocated memory (MPS): 2842 MB\n",
+      "[Loss:\t3.567]\n"
      ]
     }
    ],
@@ -407,9 +558,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Reading JSON files:   0%|          | 0/104 [10:23<?, ?file/s]\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -421,528 +579,622 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  7%|▋         | 1/13.65625 [00:00<00:01,  8.55batch/s]"
+      " 18%|█▊        | 2/11.3125 [00:00<00:03,  2.72batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0970.jpg\tEen Praurmaijang en arriveerd en den 4 te Mampau„;\t[0.1231585219502449, 0.6661331057548523, 0.20988833904266357, 0.0008200352895073593]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0971.jpg\tmet den dogter van den Panumbahan aldaar ge„; stro\t[0.13595041632652283, 0.6782530546188354, 0.18533653020858765, 0.0004599464882630855]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0972.jpg\tRaadsaam was dat de Pangerang zijn schoonzoon; zel\t[0.14104604721069336, 0.6879023313522339, 0.17063266038894653, 0.000418944691773504]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0973.jpg\tdat hem dit zeerlieff was dat de Landakers affalli\t[0.1505967080593109, 0.6758900284767151, 0.1730610728263855, 0.00045220437459647655]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0974.jpg\tRaadsaam was dat de Pangerang zijn schoonzoon; zel\t[0.15059442818164825, 0.6761804819107056, 0.1727742999792099, 0.0004507791600190103]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0975.jpg\tdat hem dit zeerlieff was dat de Landakers affalli\t[0.15530365705490112, 0.6721768975257874, 0.17207029461860657, 0.00044913310557603836]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0976.jpg\tDen Hoog Edelen Gestr Groot Agtb en wydgebiedende \t[0.20839835703372955, 0.5927276611328125, 0.19831205904483795, 0.0005618694121949375]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0977.jpg\tzulks wierd afgeslaagen eyndelyk haalden wij hem d\t[0.18795116245746613, 0.6261001229286194, 0.185466468334198, 0.0004821923212148249]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0978.jpg\tdat hem den songer bij ons heeft doen koomen want;\t[0.17730414867401123, 0.6366567015647888, 0.1855565905570984, 0.0004825497744604945]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0979.jpg\tPandak door Bantams oorst aan de Comp over gegeven\t[0.17682938277721405, 0.6302940249443054, 0.19239062070846558, 0.00048599523142911494]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0980.jpg\tLijst der Schulden van den Pangerang; Annakkoda La\t[0.2132713347673416, 0.5637866258621216, 0.22240817546844482, 0.0005338207702152431]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0981.jpg\t„donneeren dat hij een ander plaats tot zyn verbly\t[0.21429210901260376, 0.5800853371620178, 0.20514751970767975, 0.00047501755761913955]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0982.jpg\tNotitie van de Onderstaanden Proviesien dewelke; u\t[0.204691544175148, 0.5853591561317444, 0.2094675451517105, 0.0004816784639842808]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0983.jpg\t3 halve legges. voor watervaaten in der wagt; 1 p.\t[0.19902393221855164, 0.5885394215583801, 0.21196705102920532, 0.00046957339509390295]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0984.jpg\tDe Hoog Edele Gestr Groot Agtb en wydgebiedende He\t[0.19689933955669403, 0.5944874286651611, 0.2081911563873291, 0.00042209852836094797]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0985.jpg\tCoijangs rijst de eerste teegens 25 kijsers daalde\t[0.1894029825925827, 0.59218829870224, 0.21793599426746368, 0.00047268052003346384]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0986.jpg\tvan 10000 kyserdaalders ter leen zullende hij alle\t[0.19460883736610413, 0.5687077045440674, 0.23616449534893036, 0.0005189969670027494]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3524_0987.jpg\tHier meede deesen bekortende maatigen wij ons de; \t[0.20996135473251343, 0.4968831539154053, 0.2925398051738739, 0.0006156691233627498]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_3524_0988.jpg\tNotitie van Zodaanige Coopmansz:; etc: als Sariepr\t[0.22716283798217773, 0.43809202313423157, 0.33412495255470276, 0.0006201791111379862]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0481.jpg\t\t[0.339977502822876, 0.2769583761692047, 0.3822918236255646, 0.0007723094313405454]\n",
-      "BEGIN\tOUT\tNL-HaNA_1.04.02_1547_0482.jpg\t\t[0.3845382332801819, 0.3004537522792816, 0.3142997622489929, 0.0007082080701366067]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1547_0483.jpg\tSaterdagh den 4=en xber; Present den Commandeur; P\t[0.25057172775268555, 0.5393986105918884, 0.20957808196544647, 0.00045156091800890863]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0484.jpg\tna batavia, ende de tot nogh binnen dien; stad ber\t[0.22888891398906708, 0.5393284559249878, 0.23136116564273834, 0.0004214728542137891]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0485.jpg\tbedencken wat met den meester Compagnies; 2; diens\t[0.23188014328479767, 0.5283152461051941, 0.2393314242362976, 0.00047316623385995626]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0486.jpg\tgr=t agtb goede jntentien daar ontrent aan —; alle\t[0.2400600016117096, 0.46552732586860657, 0.2938116788864136, 0.0006010393844917417]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1547_0487.jpg\tEnde aangesiene het schip goudesteijn volgens —; d\t[0.22483786940574646, 0.3796190321445465, 0.3949398696422577, 0.0006031990051269531]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1547_0488.jpg\tDe voormelte Copia resolmitie door den Eh=r; Comma\t[0.19436639547348022, 0.22126343846321106, 0.5837563276290894, 0.0006138331373222172]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0456.jpg\t\t[0.32239702343940735, 0.15724734961986542, 0.5196882486343384, 0.0006673965253867209]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0457.jpg\t\t[0.3653159737586975, 0.16200658679008484, 0.47199246287345886, 0.0006849775090813637]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0458.jpg\t\t[0.3294140696525574, 0.1709538847208023, 0.4989725649356842, 0.0006594667211174965]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1547_0459.jpg\tRapport gedaen Ter ordre; van d' E. heer Adriaen V\t[0.27370670437812805, 0.4099394679069519, 0.3156913220882416, 0.0006624871748499572]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1547_0460.jpg\tdat den bovengem: veltheer, zyn seconde genaem; pi\t[0.29299893975257874, 0.21731440722942352, 0.4887281358242035, 0.0009585170773789287]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0461.jpg\t212; lieten uijtwaijen sonder te konnen uijtten op\t[0.12718608975410461, 0.6581971645355225, 0.213838130235672, 0.0007786275236867368]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0462.jpg\tden principaelsten schelm naer mijn gesegt wert ov\t[0.13529324531555176, 0.6817895770072937, 0.1824895739555359, 0.0004276258696336299]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0463.jpg\tden schadt van d' E Comp:e niet kwam aen tewijsen;\t[0.13956192135810852, 0.690478503704071, 0.16956312954425812, 0.0003963947528973222]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0464.jpg\tWingurla dus verre verrigt waeren heefen sigh zijn\t[0.14994461834430695, 0.6791617274284363, 0.17046977579593658, 0.00042380011291243136]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0465.jpg\tvoor ons thien menschen intgetal wierd opgedist; e\t[0.14823724329471588, 0.6781796216964722, 0.1731596440076828, 0.0004234856169205159]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0466.jpg\tom welke voorseijde reedenen hy velt overste den r\t[0.15629994869232178, 0.671306848526001, 0.17196501791477203, 0.00042822075192816556]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1547_0467.jpg\tWaer seven daegen zoo aen mijn lighaem te verschoo\t[0.15559862554073334, 0.6711593270301819, 0.1728082001209259, 0.0004338797880336642]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1268_1095.jpg\tIs nae aen roepingh van godes Heijsige naeme; vers\t[0.15831544995307922, 0.6693838238716125, 0.17186422646045685, 0.0004365566710475832]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1096.jpg\tberaemen op dat achtervolgens d'ordre Ind Indische\t[0.15471792221069336, 0.6716065406799316, 0.173241525888443, 0.0004340260929893702]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1097.jpg\tdwijl bevonden wort dat Eenige particoliere predic\t[0.15851885080337524, 0.6687657833099365, 0.1722734570503235, 0.0004419265897013247]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1098.jpg\td'wijl ondervonden wert dat sonder d' Inlandse tae\t[0.16432149708271027, 0.6605690121650696, 0.1746576577425003, 0.00045183897600509226]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1099.jpg\twij nader aen schrijvens Expatria vercregen hebben\t[0.1727895885705948, 0.6496272087097168, 0.17714303731918335, 0.00044016013271175325]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1100.jpg\tnaet vaderlandt ofte ook aen andre Conrespondeeren\t[0.17287340760231018, 0.6480416655540466, 0.17864476144313812, 0.00044014258310198784]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1101.jpg\tresolutie niet weijnigh versterkt door het geene v\t[0.17810386419296265, 0.6402470469474792, 0.18121905624866486, 0.0004300487053114921]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1102.jpg\tEenige veranderinge daer in te maecken en dat wij \t[0.1741306632757187, 0.6469888687133789, 0.17844557762145996, 0.0004348571819718927]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1103.jpg\t2=e; de Inlandse schoolmeesters sullen oock daer t\t[0.19097794592380524, 0.6181098818778992, 0.19040526449680328, 0.0005068654427304864]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1104.jpg\tOock dat alle predicanten die naemaels sullen Come\t[0.1917513757944107, 0.6242028474807739, 0.18360278010368347, 0.00044303268077783287]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1105.jpg\tofte oock haer advijs afte wagten bij geschrift ma\t[0.1885944902896881, 0.6239297986030579, 0.18699456751346588, 0.0004811798280570656]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1106.jpg\tgouverneur generael Anthonio van diemen loffelijck\t[0.18209587037563324, 0.6359028816223145, 0.18157057464122772, 0.00043073866982012987]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1107.jpg\tdat de broederen haer met de kerken vergaderingh r\t[0.18156976997852325, 0.6367211937904358, 0.1812719851732254, 0.0004370612441562116]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1268_1108.jpg\tder H:r saeken die daer toe sullen werden gecommit\t[0.17571915686130524, 0.6444221138954163, 0.17942769825458527, 0.00043096698937006295]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1268_1109.jpg\tg'admitteert en tot godes kerke aengenomen werden \t[0.18611912429332733, 0.6301312446594238, 0.1833193451166153, 0.00043035822454839945]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_3446_0595.jpg\tAan De Edele Hoog Agtb„e Heeren; Bewindhebberen va\t[0.18293602764606476, 0.632973849773407, 0.1836433708667755, 0.0004467506951186806]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0596.jpg\tOctober 1776 met de voorzeilder de Boven; . .; „ke\t[0.18872889876365662, 0.6273429989814758, 0.1834936887025833, 0.00043443875620141625]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0597.jpg\tinhouden 21339: lb: een minderheijt bevonden; is v\t[0.18785050511360168, 0.6266059279441833, 0.18510478734970093, 0.00043875325354747474]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0598.jpg\tverantwoord en de overige 139: lb. bij naweging; v\t[0.18952974677085876, 0.6242184638977051, 0.1858091652393341, 0.0004425727529451251]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0599.jpg\tbreng van het schip Mentor een vol vat bruto; wege\t[0.18957939743995667, 0.6221216917037964, 0.18785247206687927, 0.00044644682202488184]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0600.jpg\tverantwoord en de overige 139: lb. bij nawe„; van \t[0.18980750441551208, 0.6129487156867981, 0.1967705935239792, 0.0004731705121230334]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0601.jpg\tbreng van het schip Mentor een vol vat bruto; wege\t[0.1840009242296219, 0.6049435138702393, 0.21060466766357422, 0.00045090634375810623]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3446_0602.jpg\tBotthland, Topkensburg, de Held Wolthemade, Mentor\t[0.19885443150997162, 0.5540777444839478, 0.24655961990356445, 0.0005082078278064728]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_3446_0603.jpg\tBatavia; in 't Casteel den; 25:e october; waar mee\t[0.2246626764535904, 0.48094192147254944, 0.2936418652534485, 0.0007535244221799076]\n",
-      "END\tBEGIN\tNL-HaNA_1.04.02_2542_0114.jpg\tVan Mallabaar onder dato; 9. stux te weeten; 6. ma\t[0.2611084580421448, 0.26199063658714294, 0.47596052289009094, 0.0009403910953551531]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1060_0435.jpg\tAlsoo het schip der Goes, als t'Jacht Cleijn Enckh\t[0.9996637105941772, 0.0002524361771065742, 5.55374936084263e-05, 2.8267319066799246e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0436.jpg\tOp heden den 5 feb. @ 1614, door beroep vanden E. \t[0.0012747891014441848, 0.997553288936615, 0.0011668851366266608, 5.150438937562285e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0437.jpg\t@ 1615. Dondergeschreven te soonen; Soo Is bij d' \t[0.0007243358995765448, 0.9982724189758301, 0.0009999239118769765, 3.3418723432987463e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0438.jpg\tDen 19 feb. . vernomen hebbende op de factorije to\t[0.0006676050252281129, 0.9983349442481995, 0.0009944145567715168, 3.1268480142898625e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0439.jpg\tErt Dircx wttgevaren voor Soldaet, opt schip Banta\t[0.0006568318349309266, 0.9983606934547424, 0.000979323056526482, 3.1010447401058627e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0440.jpg\tComptoir deeart sullen gaen, omme door den opperco\t[0.0006553619750775397, 0.9983624815940857, 0.0009790909243747592, 3.096177124461974e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0441.jpg\tAl500. Anthonij Caen, getrout met Jannetien Gillis\t[0.0006557885790243745, 0.9983627200126648, 0.0009783399291336536, 3.096124828516622e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0442.jpg\tssouden mogen geraecken, &ne ten derden vermits al\t[0.0006503397016786039, 0.9983595013618469, 0.0009869943605735898, 3.0627386422565905e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0443.jpg\tAlsoo tot noch toe geen schepen wt het vaderlant, \t[0.0006529833772219718, 0.9983555674552917, 0.000988348270766437, 3.0696569410793018e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0444.jpg\tNaerder gelet sijnde, volgens apostile door d Ed. \t[0.0006359292892739177, 0.9983248114585876, 0.001036216039210558, 3.0179642180883093e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0445.jpg\t@ 1615; E; Den 14e. septemb. d'onderges raden, opt\t[0.0006385945598594844, 0.9982671737670898, 0.0010911064455285668, 3.07789468934061e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0446.jpg\tge; Alsoo 'T schip Esterre, tot zijnne te doene vo\t[0.0006711218156851828, 0.9979767203330994, 0.0013488966505974531, 3.373667823325377e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1060_0447.jpg\tMaendach den xiiije Decemb. @ 1615 &; Alsoo bij de\t[0.0008880437817424536, 0.9964327812194824, 0.0026738967280834913, 5.252621122053824e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1060_0448.jpg\tSivert Sipkens sargeant die de voors compe. tot nu\t[0.00011219384032301605, 0.00034786525066010654, 0.9995321035385132, 7.816047400410753e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1066_0065.jpg\tNo. 1— Originelen missive door d' H=r Presidt Cocn\t[0.9980794191360474, 0.0010041077621281147, 0.0007949898717924953, 0.00012147149391239509]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 22%|██▏       | 3/13.65625 [00:00<00:00, 13.72batch/s]"
+      " 27%|██▋       | 3/11.3125 [00:01<00:03,  2.38batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1647_0632.jpg\tVan Macassar Anno 1701—; Vervolgens quam by den He\t[0.12395356595516205, 0.6638548970222473, 0.21137934923171997, 0.0008122037397697568]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0633.jpg\tVan Macassar Anno 1701; Van Macassar Anno 1701.; a\t[0.13473038375377655, 0.6803565621376038, 0.1844596564769745, 0.00045336579205468297]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0634.jpg\tVan Macassar Anno 1701; Van Macassar Anno 1701; va\t[0.140029177069664, 0.6896322965621948, 0.16992247104644775, 0.00041610473999753594]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0635.jpg\tVan Macassar Anno 1701; Van Macassar Anno 1701; ve\t[0.1512736678123474, 0.6765015125274658, 0.1717754304409027, 0.0004493932065088302]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0636.jpg\tVan Macassar Anno 1701; Van Macassar A„o 1701; het\t[0.1493915617465973, 0.6775469183921814, 0.172615647315979, 0.00044592225458472967]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0637.jpg\tVan Macassar Anno 1701; Van Macassar A„o 1701.; mo\t[0.1560990810394287, 0.6709672808647156, 0.17248138785362244, 0.0004522496019490063]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0638.jpg\tVan Macassar Anno 1701.; Van Macassar Anno 1701; g\t[0.22917282581329346, 0.5602574944496155, 0.20999546349048615, 0.0005741496570408344]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0639.jpg\tVan; Macassar A„o 1701; Van Macassar A„o 1701; nae\t[0.20590084791183472, 0.5975102782249451, 0.19611206650733948, 0.0004768311628140509]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0640.jpg\tVan Macassar Anno 1701.; Van Macassar Anno 1701; W\t[0.19229285418987274, 0.6120503544807434, 0.19518201053142548, 0.0004747292259708047]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1647_0641.jpg\tVan Macassar A„o 1701; Van Macassar Anno 1781; den\t[0.19082403182983398, 0.6125960350036621, 0.19611093401908875, 0.0004689886118285358]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1647_0642.jpg\tVan Macassar A„o 1701; Van Macassar Anno 1701; had\t[0.19552946090698242, 0.5951502323150635, 0.20885595679283142, 0.00046436523552984]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1060_0435.jpg\tAlsoo het schip der Goes, als t'Jacht Cleijn Enckh\t[0.20790059864521027, 0.59159916639328, 0.20004522800445557, 0.00045504161971621215]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0436.jpg\tOp heden den 5 feb. @ 1614, door beroep vanden E. \t[0.20746584236621857, 0.590502917766571, 0.2015550583600998, 0.0004761872114613652]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0437.jpg\t@ 1615. Dondergeschreven te soonen; Soo Is bij d' \t[0.2073177844285965, 0.5901011824607849, 0.20211003720760345, 0.000470929458970204]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0438.jpg\tDen 19 feb. . vernomen hebbende op de factorije to\t[0.20750676095485687, 0.5922558903694153, 0.19978193938732147, 0.0004553981707431376]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0439.jpg\tErt Dircx wttgevaren voor Soldaet, opt schip Banta\t[0.22996683418750763, 0.5551401972770691, 0.2143542468547821, 0.0005387505516409874]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0440.jpg\tComptoir deeart sullen gaen, omme door den opperco\t[0.2272082269191742, 0.5642900466918945, 0.20801609754562378, 0.0004855831793975085]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0441.jpg\tAl500. Anthonij Caen, getrout met Jannetien Gillis\t[0.21940892934799194, 0.5698021054267883, 0.21028819680213928, 0.0005007454892620444]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0442.jpg\tssouden mogen geraecken, &ne ten derden vermits al\t[0.20794738829135895, 0.5811906456947327, 0.21043384075164795, 0.00042809065780602396]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0443.jpg\tAlsoo tot noch toe geen schepen wt het vaderlant, \t[0.20441082119941711, 0.5810114741325378, 0.2141304612159729, 0.0004472167929634452]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0444.jpg\tNaerder gelet sijnde, volgens apostile door d Ed. \t[0.1998315155506134, 0.5863195061683655, 0.21342794597148895, 0.0004210502956993878]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0445.jpg\t@ 1615; E; Den 14e. septemb. d'onderges raden, opt\t[0.1984020471572876, 0.5831089019775391, 0.21802616119384766, 0.0004628821916412562]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0446.jpg\tge; Alsoo 'T schip Esterre, tot zijnne te doene vo\t[0.1919216811656952, 0.5625850558280945, 0.24500028789043427, 0.0004929662100039423]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0447.jpg\tMaendach den xiiije Decemb. @ 1615 &; Alsoo bij de\t[0.20451603829860687, 0.5404966473579407, 0.2543669641017914, 0.0006203789380379021]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1060_0448.jpg\tSivert Sipkens sargeant die de voors compe. tot nu\t[0.22536660730838776, 0.4459518790245056, 0.3280097246170044, 0.0006718285731039941]\n",
-      "END\tBEGIN\tNL-HaNA_1.04.02_1066_0065.jpg\tNo. 1— Originelen missive door d' H=r Presidt Cocn\t[0.21636663377285004, 0.30262237787246704, 0.48043110966682434, 0.0005797959747724235]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0348.jpg\t\t[0.3304864764213562, 0.18544264137744904, 0.4834105670452118, 0.0006603572983294725]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0349.jpg\t\t[0.3204514682292938, 0.20593197643756866, 0.47292768955230713, 0.0006888258503749967]\n",
-      "END\tOUT\tNL-HaNA_1.04.02_1547_0350.jpg\t\t[0.35588353872299194, 0.2415366917848587, 0.40190452337265015, 0.0006752334302291274]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1547_0351.jpg\tTranslaat ola door haar E:; heer Commandeur adriaa\t[0.26451611518859863, 0.5019306540489197, 0.23303744196891785, 0.0005158418207429349]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0352.jpg\tgegeven werd op dit alle onlusten verweijderinghe \t[0.2587278485298157, 0.4308733642101288, 0.309732049703598, 0.0006668136338703334]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1547_0353.jpg\ten het Cochinisz rijk herwaarts te senden om over \t[0.27576541900634766, 0.22703464329242706, 0.4962993264198303, 0.0009006165200844407]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1506_1034.jpg\t-; d; E; 7.; decken; 8; 2; van de; 5; ƒ; 3; E; E; \t[0.11448346078395844, 0.6758450269699097, 0.2089116871356964, 0.0007598279044032097]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1506_1035.jpg\tbinnewater; een lamme; D95; same; uijt; ies; Cas; \t[0.1325017213821411, 0.6776821613311768, 0.1893334835767746, 0.00048264767974615097]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1506_1036.jpg\t30 vrs; o; Janor; 6; 5o; e; x; 116; E; 6.; 1.; :; \t[0.13322339951992035, 0.6764953136444092, 0.18973992764949799, 0.0005413414328359067]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1506_1037.jpg\tk; „noortvelt; rogons; „1; rsame; uijt; eruijt; ƒ;\t[0.173891082406044, 0.5663397908210754, 0.25919654965400696, 0.0005726039526052773]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_3060_0043.jpg\tNa dat de Leeden deeser Vergaadering bij een geroe\t[0.18850813806056976, 0.4708155393600464, 0.3400689959526062, 0.0006073274998925626]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0044.jpg\t\t[0.35526204109191895, 0.30140119791030884, 0.34264424443244934, 0.0006925964262336493]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0045.jpg\t\t[0.3702048063278198, 0.28144121170043945, 0.3476824164390564, 0.0006715888739563525]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0046.jpg\t\t[0.3832387924194336, 0.28568893671035767, 0.3304426074028015, 0.0006296462379395962]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0047.jpg\tWoensdag den 13: ' October A„o 1762.; Na dat de Le\t[0.2532379925251007, 0.5288215279579163, 0.21744978427886963, 0.0004906879039481282]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0048.jpg\tNagesien; G„s V„n Aken\t[0.2602235972881317, 0.4688705503940582, 0.2703266739845276, 0.000579180137719959]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0049.jpg\tWoensdag den 13.:' October A„o 1762.; Na dat de Le\t[0.272487074136734, 0.4100693464279175, 0.31683218479156494, 0.0006113972049206495]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0050.jpg\t\t[0.35832878947257996, 0.2931559383869171, 0.34781110286712646, 0.0007041605422273278]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0051.jpg\tDingsdag Den 2:' November A„o 1762. —; Den Raad bi\t[0.24837808310985565, 0.5291040539741516, 0.2220669984817505, 0.00045091696665622294]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0052.jpg\tOver te haalen geweest, dan ruijm, een halff Capit\t[0.24305762350559235, 0.5128145813941956, 0.24355003237724304, 0.0005777910118922591]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0053.jpg\tDen bottelier Jan Fredrik Smit, van SHage; Hoffmee\t[0.2594742178916931, 0.46821409463882446, 0.27171051502227783, 0.0006011686054989696]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0054.jpg\tNagesien; P: D Lahaije\t[0.24756570160388947, 0.4138874113559723, 0.3379914462566376, 0.0005554512608796358]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3060_0055.jpg\t\t[0.34331732988357544, 0.25777530670166016, 0.39814460277557373, 0.0007628189050592482]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0056.jpg\tNagesien; G: B: D Leeuw; d\t[0.2867405414581299, 0.4243544340133667, 0.28829699754714966, 0.000607942754868418]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3060_0057.jpg\tMaandag Den 15„e November A„o 1762. —; Het ingedie\t[0.3430905342102051, 0.30784010887145996, 0.34830743074417114, 0.0007619906100444496]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3060_0058.jpg\t\t[0.3511180877685547, 0.2627635598182678, 0.38536855578422546, 0.0007497703190892935]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0059.jpg\tAan den wel Edelen Agtb: Heere; Fredrik Willem Win\t[0.3172149956226349, 0.37618687748908997, 0.3060208261013031, 0.0005772957811132073]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0060.jpg\t\t[0.36307138204574585, 0.2818451225757599, 0.35429853200912476, 0.0007849361863918602]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0061.jpg\t\t[0.36604446172714233, 0.2974752187728882, 0.335798054933548, 0.0006822844734415412]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0062.jpg\tNagesien; J:B: D Leeuw.\t[0.305795282125473, 0.39683598279953003, 0.2968212962150574, 0.0005473951459862292]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0063.jpg\t\t[0.37496140599250793, 0.29032444953918457, 0.3339678645133972, 0.0007462769863195717]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0064.jpg\t\t[0.39441657066345215, 0.29403460025787354, 0.31081774830818176, 0.0007310580695047975]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0065.jpg\tE:E: Agtbaaren Heer Johannes Heijnouts; Sondergete\t[0.27511805295944214, 0.5208274722099304, 0.2035953253507614, 0.0004591619363054633]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_3060_0066.jpg\tNoering hem daar toe sijne hulpe leenen; Voor 't o\t[0.24005600810050964, 0.535645067691803, 0.22389616072177887, 0.00040278100641444325]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1088_0511.jpg\tNaer dat den 8en. septembr 1625, het fergatt Surat\t[0.24713720381259918, 0.5236415266990662, 0.2287902981042862, 0.0004309544456191361]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0512.jpg\tdie van Lohoe waren hem gevolcht, tot op lebeleeuw\t[0.24243740737438202, 0.5134482979774475, 0.24364732205867767, 0.0004669547488447279]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0513.jpg\twederom afgesonden, naar Bouro, om te vernemen, wa\t[0.2566356658935547, 0.4456460177898407, 0.2970398962497711, 0.0006783909047953784]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1088_0514.jpg\tende ten deele onwillich, soo dat met schoon spree\t[0.2650003731250763, 0.23765206336975098, 0.49646493792533875, 0.0008826314588077366]\n"
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0348.jpg\t\t[3.767828457057476e-05, 1.168915241578361e-05, 1.6890284314285964e-05, 0.9999337196350098]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0349.jpg\t\t[1.3423024938674644e-05, 5.066107860329794e-06, 6.1292248574318364e-06, 0.9999754428863525]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0350.jpg\t\t[2.89409035758581e-05, 1.1263072337897029e-05, 1.1508109309943393e-05, 0.9999483823776245]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0351.jpg\tTranslaat ola door haar E:; heer Commandeur adriaa\t[0.9994751811027527, 0.00016204184794332832, 5.188388240640052e-05, 0.0003109582175966352]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0352.jpg\tgegeven werd op dit alle onlusten verweijderinghe \t[0.002426056656986475, 0.9959057569503784, 0.0015960998134687543, 7.202728738775477e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0353.jpg\ten het Cochinisz rijk herwaarts te senden om over \t[0.0002140397991752252, 0.0006525940843857825, 0.9990953207015991, 3.8060639781178907e-05]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 44%|████▍     | 6/13.65625 [00:00<00:00, 16.61batch/s]"
+      " 35%|███▌      | 4/11.3125 [00:03<00:06,  1.06batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0515.jpg\tons voor antwoort, dat wel waar was, dat sijn Vade\t[0.12300992757081985, 0.6676484942436218, 0.2085222452878952, 0.0008192991372197866]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0516.jpg\tnoch al wel toeginck, ende mijn hier van noch vrij\t[0.1371178925037384, 0.6777298450469971, 0.18468590080738068, 0.0004663012514356524]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0517.jpg\tblijcken wat parthij hij hielt van dese uijr affso\t[0.14017949998378754, 0.6881232261657715, 0.17127247154712677, 0.0004248098412062973]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0518.jpg\tdus lange was gedaen, hebben den raet dit in Beden\t[0.15155616402626038, 0.673597514629364, 0.17435970902442932, 0.00048659005551598966]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0519.jpg\tte mogen werden, met cruijt ende Loot, ende soo he\t[0.14337728917598724, 0.664137065410614, 0.19196680188179016, 0.0005187909700907767]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0520.jpg\tDen 9=en d=o smorgens, quamen voor Oerien, ofte no\t[0.15297247469425201, 0.6291505098342896, 0.21734876930713654, 0.0005282526835799217]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0521.jpg\tmede die van Cabau, den Sergeant aldaer op Hatuha \t[0.17781686782836914, 0.5413885712623596, 0.2802218198776245, 0.0005727903917431831]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0522.jpg\tSijn voorts doorgepangaijt naer Oma, de corcoiren \t[0.22235259413719177, 0.4052996337413788, 0.37184420228004456, 0.0005035870708525181]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1088_0523.jpg\t\t[0.34384027123451233, 0.27237260341644287, 0.38304245471954346, 0.0007446848321706057]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1088_0524.jpg\t\t[0.35519739985466003, 0.27058297395706177, 0.37346336245536804, 0.0007562588434666395]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0525.jpg\t\t[0.38397568464279175, 0.2655954658985138, 0.3497171998023987, 0.0007117179338820279]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0526.jpg\t\t[0.38085898756980896, 0.2699090540409088, 0.3484577536582947, 0.0007742696907371283]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0527.jpg\t\t[0.38876497745513916, 0.30107226967811584, 0.30947038531303406, 0.0006923926412127912]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0528.jpg\t\t[0.37730973958969116, 0.2639063000679016, 0.35803547501564026, 0.0007485183887183666]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0529.jpg\t\t[0.3985578417778015, 0.26463231444358826, 0.3360494077205658, 0.0007604577112942934]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0530.jpg\t\t[0.41898423433303833, 0.2835767865180969, 0.2968009114265442, 0.0006380120757967234]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0531.jpg\t\t[0.4124943017959595, 0.2477325201034546, 0.3391472399234772, 0.0006259811343625188]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0532.jpg\tin Ambonia tsedert 8 septemb.; Daghregister vant g\t[0.3637464642524719, 0.3505188524723053, 0.28517234325408936, 0.000562339264433831]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0533.jpg\t\t[0.43763428926467896, 0.27337101101875305, 0.28840354084968567, 0.0005911268526688218]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0534.jpg\tCopien van resolutien tsedert; 21 Julij 1628. tet \t[0.3155929148197174, 0.4904439449310303, 0.1934983730316162, 0.00046481186291202903]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0535.jpg\tberockt ons alsoo weder werck, geeft ons de handen\t[0.2672829031944275, 0.5335298180580139, 0.19881278276443481, 0.000374471303075552]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0536.jpg\tgewacht, dat sulcx de ongelegentheijt van tijt, en\t[0.25624993443489075, 0.5421118140220642, 0.2012500911951065, 0.00038813703577034175]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0537.jpg\tDen 22.en s=o vertrocken van lato ende Holoij, end\t[0.25562939047813416, 0.5396353006362915, 0.20433470606803894, 0.0004005951341241598]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0538.jpg\tdit geweest sijn, hebben nu inder daatr bevonden, \t[0.26257631182670593, 0.5346569418907166, 0.20233187079429626, 0.00043485016794875264]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0539.jpg\tende gewillich aengenomen, hadden mede al begonnen\t[0.2886029779911041, 0.5120407938957214, 0.1988372653722763, 0.0005188938230276108]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0540.jpg\tDen 6. H=o Ist fargatt Suratte, Wederom op Amboijn\t[0.2594652771949768, 0.5330973863601685, 0.20700904726982117, 0.00042828175355680287]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0541.jpg\tOuer het Verlies van Rommite, hadden ouer Hittoe, \t[0.2562984824180603, 0.5362821817398071, 0.20701301097869873, 0.0004063316446263343]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0542.jpg\twaren, het selue achter nelis hoeck te brengen, om\t[0.24197758734226227, 0.5390496253967285, 0.21856585144996643, 0.0004069438436999917]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0543.jpg\t244; voorganis, datmen ons niet en mocht vertrouwe\t[0.24281878769397736, 0.5282832980155945, 0.22848521173000336, 0.0004127765423618257]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0544.jpg\tvrouw, den man niet mede toebehoorde, niet meer an\t[0.23340623080730438, 0.5220819711685181, 0.24405722320079803, 0.0004545701667666435]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0545.jpg\tsoete middelen te werck gaen, hoewel daar mede nie\t[0.25791940093040466, 0.45204269886016846, 0.2893565595149994, 0.0006813481450080872]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1088_0546.jpg\tsoude mogen bewaert leggen, maer alst nu alsoo bes\t[0.26809072494506836, 0.24341358244419098, 0.48758774995803833, 0.0009079193696379662]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0547.jpg\tsij seijden dat op Hattamana, den Jongen Coninck, \t[0.1267382651567459, 0.6588939428329468, 0.21358662843704224, 0.0007811356917954981]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0548.jpg\tuijt de quartieren van hittoe, dit heele Mosson, m\t[0.13476139307022095, 0.6825922131538391, 0.18221749365329742, 0.00042890210170298815]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0549.jpg\tdaer van wachten soude, hebben de gevangenen ontsl\t[0.13901746273040771, 0.6912644505500793, 0.16932040452957153, 0.00039770713192410767]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0550.jpg\thebben geconsenteert, haer best te doen, ende reve\t[0.14931754767894745, 0.6800357103347778, 0.17022162675857544, 0.00042507576290518045]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0551.jpg\tselffs dootlijck gewont, waar op die van Cambello \t[0.1476431041955948, 0.6789968609809875, 0.17293523252010345, 0.00042479002149775624]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0552.jpg\tspoedich affhandelen, ende ons laeten weeten, waer\t[0.1557537019252777, 0.6720818877220154, 0.17173460125923157, 0.0004298138665035367]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0553.jpg\tpattij naij, met haer souden afsenden, om den Coni\t[0.15486840903759003, 0.6721320152282715, 0.1725643277168274, 0.0004352289834059775]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0554.jpg\tbegeerden alleen te verstaen, wat antwoort den kim\t[0.1576693207025528, 0.6702572107315063, 0.17163555324077606, 0.0004379762685857713]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0555.jpg\tsij hadden geseijt voor ons bevreest te weesen, en\t[0.15413637459278107, 0.6724469661712646, 0.17298132181167603, 0.0004353015392553061]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0556.jpg\tTarnataensen aenhanck, vande custe van Ceram: niet\t[0.15783248841762543, 0.669690728187561, 0.1720336228609085, 0.00044316769344732165]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0557.jpg\top houden, conde niet bedencken wat Excusien sij d\t[0.16365547478199005, 0.6614834070205688, 0.17440761625766754, 0.00045346535625867546]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0558.jpg\tvereenichde Nederlanden, maer deselue hebben haren\t[0.17205794155597687, 0.6506412625312805, 0.17685900628566742, 0.0004418030730448663]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0559.jpg\tte werden, het welck wij hebben naergecommen, ende\t[0.17198924720287323, 0.6493304371833801, 0.17823895812034607, 0.0004413993447087705]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0560.jpg\ttraecheijt des Conincx van Saulauw, niet en soude \t[0.17608331143856049, 0.6433331370353699, 0.18015241622924805, 0.00043117234599776566]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0561.jpg\top dat alsoo de oude vruntschap, mocht vernieuwt w\t[0.16751140356063843, 0.6570090055465698, 0.17504067718982697, 0.0004388841916806996]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0562.jpg\tarmoede die zijn bolck leet, doch ten laetsten hei\t[0.16767334938049316, 0.6517078280448914, 0.1801905333995819, 0.0004282818699721247]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0563.jpg\tte assisteeren.; Capn. Hittoe quam ons mede besoec\t[0.1728457361459732, 0.6492084860801697, 0.17750990390777588, 0.0004358838777989149]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0564.jpg\tHebben den gesant Noffa Maniera, bij ons ontbooden\t[0.17864994704723358, 0.6377575993537903, 0.18313351273536682, 0.00045899144606664777]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0565.jpg\tgoetgevoelen vandese saack; Wij Eijschten vanden g\t[0.171361044049263, 0.651186466217041, 0.17701546847820282, 0.00043705428834073246]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0566.jpg\tDit staat ons vreemt aen, connes oock niet geloove\t[0.1696617603302002, 0.6536412835121155, 0.17626269161701202, 0.00043425356852822006]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0567.jpg\tworden, met veel meer schoone woorden daar noch bi\t[0.1631295084953308, 0.660554826259613, 0.17588947713375092, 0.0004261934373062104]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0568.jpg\tnaar Hittoe, aenden ondercoopman vant Nederlants C\t[0.1811760663986206, 0.6365489959716797, 0.18184778094291687, 0.00042720790952444077]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0569.jpg\tdat denselven soude doen translateren, op dat aen \t[0.17453879117965698, 0.6420176029205322, 0.1830010563135147, 0.0004425579681992531]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1088_0570.jpg\tende geen meer en haddent, schreeff Helenij aen on\t[0.18532457947731018, 0.6303381323814392, 0.18388479948043823, 0.00045248703099787235]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_8099_0205.jpg\tVan Ternaten onder dato 11:' 7ber: 1732; van alle \t[0.23320156335830688, 0.5606920123100281, 0.20551282167434692, 0.0005935766967013478]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0206.jpg\tVan Ternaten onder dato 11:' Septemb:r 1732; Lauwt\t[0.21736741065979004, 0.5752289891242981, 0.2069225311279297, 0.0004811066610272974]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0207.jpg\tVan Ternaten onder dato 11:' 7ber: 1732; door hem \t[0.21378496289253235, 0.5740087628364563, 0.21172350645065308, 0.0004827335651498288]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0208.jpg\tTernaten onder dato 11:' 7ber: 1732; Van; „dugting\t[0.20884670317173004, 0.556013822555542, 0.23466110229492188, 0.00047835256555117667]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0209.jpg\tTernaten onder dato 11:' 7ber: 1732; Van; Ternaten\t[0.25902488827705383, 0.4668359160423279, 0.27356189489364624, 0.0005773216253146529]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0210.jpg\tTernaten onder dato 11:' Sepb: 1732; Van; voor ops\t[0.21809186041355133, 0.5306696891784668, 0.2506937086582184, 0.0005447531584650278]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0211.jpg\tTernaten onder dato 17:' 7ber: 1732; E; Van; en we\t[0.2343817949295044, 0.4645187258720398, 0.30031129717826843, 0.000788263336289674]\n",
-      "END\tIN\tNL-HaNA_1.04.02_8099_0212.jpg\tVan Ternaten onder dato 11:' Jber: 1732; Saturdag \t[0.2649657726287842, 0.25235363841056824, 0.48173031210899353, 0.0009503070614300668]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0213.jpg\tVan Ternaten onder dato 11:' Jber: A„o 1732; AAan \t[0.12641237676143646, 0.6644463539123535, 0.2083406299352646, 0.0008006145944818854]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0214.jpg\tVan Ternaten onder dato 11:' Septemb: A„o 1732; ee\t[0.13823112845420837, 0.6796778440475464, 0.18163222074508667, 0.00045873437193222344]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0215.jpg\tVan Ternaten onder dato 11:' Septemb: 1732; waar v\t[0.2025464028120041, 0.5984074473381042, 0.19847528636455536, 0.0005708063836209476]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0216.jpg\tTernaten onder dato 11:' 7ber: A„o 1732; Van; uijt\t[0.1834653615951538, 0.6315121054649353, 0.18450617790222168, 0.000516348285600543]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_8099_0217.jpg\tVan Ternaten onder dato 11:' Septemb: 1732; s geli\t[0.18318724632263184, 0.6054268479347229, 0.21083082258701324, 0.0005551087087951601]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1070_0199.jpg\t2 saeckers Elck van 3000 lb; 2 halve dittos elck v\t[0.21341148018836975, 0.5050438046455383, 0.2808862328529358, 0.0006585560040548444]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1070_0200.jpg\t\t[0.3837254047393799, 0.305451899766922, 0.31007444858551025, 0.0007482473738491535]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1070_0201.jpg\tAdriaen gerritsz van utrecht sergiant; marijn Ding\t[0.25310689210891724, 0.5502375364303589, 0.19621437788009644, 0.0004412290873005986]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1509_1538.jpg\tMonsterolle van alle sComp:s Loontreckende; Monste\t[0.22532926499843597, 0.5766720175743103, 0.19758208096027374, 0.00041665317257866263]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1539.jpg\tdienaren dewelcke in't Cormandelse Gouvernement bi\t[0.22118012607097626, 0.5826095938682556, 0.1957959532737732, 0.00041435123421251774]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1540.jpg\t339. en 35. persoonen p=r Transport. —; Namen, Toe\t[0.22883693873882294, 0.567142903804779, 0.2036011666059494, 0.00041893793968483806]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1541.jpg\t90; d=o.. . ..; Adsistent; Chirurgijn. . . . ƒ 36.\t[0.23830784857273102, 0.5576146841049194, 0.2036828100681305, 0.0003946674696635455]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1542.jpg\t339 en 74. persoonen P=r Transport; Namen, Toename\t[0.23833869397640228, 0.556958794593811, 0.20429331064224243, 0.00040916461148299277]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1543.jpg\tsiekevaar. . . ƒ 20. walcheren. . . . . 1662. Zeel\t[0.23904012143611908, 0.5565422177314758, 0.2040257453918457, 0.000391931040212512]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1544.jpg\t339. en 113. persoonen P=r Transport.; Namen, Toen\t[0.233232319355011, 0.5661326050758362, 0.2002490758895874, 0.0003860536962747574]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1545.jpg\tp:l timmerman. ƒ 11. d' bergh China. . . 1682. Ams\t[0.23228438198566437, 0.5626633167266846, 0.20466545224189758, 0.0003868199128191918]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1546.jpg\t339. en 155. persoonen P=r Transport; 1. Abraham f\t[0.23553071916103363, 0.5620721578598022, 0.20200437307357788, 0.00039267970714718103]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1547.jpg\t90; 90; 90; 90; D=o; d=o; 90; D=o; 90; 90; D=o; D=\t[0.23814980685710907, 0.5549279451370239, 0.20649434626102448, 0.0004278637934476137]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1548.jpg\t339. en 195. persoonen P=r Transport —; Namen, Toe\t[0.23055964708328247, 0.5678804516792297, 0.2011728584766388, 0.0003870239306706935]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1549.jpg\t90; 90; 90; 40; 90; D=; D=o; D=o; D=o; D=o; D=o; 9\t[0.23026658594608307, 0.5681942701339722, 0.2011461704969406, 0.00039291035500355065]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1550.jpg\t339. en 236. persoonen p=r Transport; Namen, Toena\t[0.22447910904884338, 0.5751739740371704, 0.1999584287405014, 0.0003884818288497627]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1551.jpg\tdo.; 90; do; 90; do; do; 90; 90; 90; D=o. . . . „;\t[0.23675177991390228, 0.5593635439872742, 0.20350080728530884, 0.00038388065877370536]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1552.jpg\t339. en 278. persoonen P=r Transport; Namen, Toena\t[0.2351241260766983, 0.5612884163856506, 0.20318685472011566, 0.0004005790106020868]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1553.jpg\tw:t p:r met wat schip in india; presente qualitijt\t[0.24124285578727722, 0.5547809600830078, 0.20358724892139435, 0.00038894012686796486]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1554.jpg\t339. en 320. persoonen p=r Transport; Namen, Toena\t[0.23958231508731842, 0.553878664970398, 0.2061389833688736, 0.0003999731270596385]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1555.jpg\tCommand:r te water en te; noorder Cormandel; „coop\t[0.24106480181217194, 0.5505529046058655, 0.20796671509742737, 0.0004155739152338356]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1556.jpg\t356. persoonen p=r Transport; Namen toenamen en ge\t[0.23097911477088928, 0.5443649291992188, 0.22423259913921356, 0.00042334452155046165]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1557.jpg\tw:t p:r met wat schip in jndia..; presente qualiti\t[0.24947476387023926, 0.5082489848136902, 0.24177466332912445, 0.000501569826155901]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1558.jpg\t391. persoonen p:r transport; Namen, Toenamen, en \t[0.23669962584972382, 0.5312386155128479, 0.2316216677427292, 0.0004401302139740437]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1559.jpg\tw:t p:r met wat schip in; presente qualitijt. maen\t[0.22907333076000214, 0.521134614944458, 0.2493247240781784, 0.0004673415969591588]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1560.jpg\tNamen Toenamen en Geboorte plaatsen; 1. bastiaan I\t[0.2510015368461609, 0.45092105865478516, 0.2973700761795044, 0.000707298400811851]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1509_1561.jpg\tw:t p:r met wat schip in jndia/; presente qualitij\t[0.2744083106517792, 0.24395757913589478, 0.48071447014808655, 0.0009195776074193418]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1506_1034.jpg\t-; d; E; 7.; decken; 8; 2; van de; 5; ƒ; 3; E; E; \t[0.999672532081604, 0.0002436629729345441, 5.570215216721408e-05, 2.817159656842705e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1506_1035.jpg\tbinnewater; een lamme; D95; same; uijt; ies; Cas; \t[0.0013309026835486293, 0.9972808361053467, 0.0013826104113832116, 5.614747806248488e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1506_1036.jpg\t30 vrs; o; Janor; 6; 5o; e; x; 116; E; 6.; 1.; :; \t[0.0011187694035470486, 0.9959751963615417, 0.0029000823851674795, 5.9029798649135046e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1506_1037.jpg\tk; „noortvelt; rogons; „1; rsame; uijt; eruijt; ƒ;\t[0.00011362581426510587, 0.0002934639051090926, 0.9995860457420349, 6.863442195026437e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 59%|█████▊    | 8/13.65625 [00:00<00:00, 14.59batch/s]"
+      " 44%|████▍     | 5/11.3125 [00:04<00:07,  1.26s/batch]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1562.jpg\t464. persoonen p:r transport; Namen Toenamen en Ge\t[0.12717807292938232, 0.6669479608535767, 0.20509423315525055, 0.0007797127473168075]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1563.jpg\tp:r coopm: en opperh:t van; tegenep: en p:r novo: \t[0.20447637140750885, 0.6038725972175598, 0.19107909500598907, 0.0005719168693758547]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1564.jpg\t504. persoonen p=r Transport; Namen, Toenamen, en \t[0.1593000441789627, 0.6723264455795288, 0.16791807115077972, 0.0004554121114779264]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1565.jpg\tw:t p:r met wat schip in; presente qualitijt maent\t[0.16074635088443756, 0.6690497398376465, 0.16975799202919006, 0.00044589844765141606]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1566.jpg\tOp Nagapatnam zijn nogh bescheijden d'volgende; Bo\t[0.16036903858184814, 0.6660071015357971, 0.17316178977489471, 0.0004620686231646687]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1509_1567.jpg\t103 en 84. persoonen p:r transport; 1. toatongoe v\t[0.1625780314207077, 0.6644097566604614, 0.17257022857666016, 0.000441959360614419]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1490_0583.jpg\tCopije Secrete Resolutien; genomen bij de Ho: Rege\t[0.16546478867530823, 0.6603347063064575, 0.1737585961818695, 0.0004418912576511502]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0584.jpg\tin presentie; van zijn Ed. t te; volbrengen, soo s\t[0.1640106588602066, 0.6632469296455383, 0.17229853570461273, 0.0004438703472260386]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0585.jpg\tdat 's Comp. s dienaren en wel voorna„; mentlijk p\t[0.16316282749176025, 0.6633104681968689, 0.17308121919631958, 0.00044546095887199044]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0586.jpg\tbij ons te boeck staen voor niet wel; geintentione\t[0.16387243568897247, 0.6629466414451599, 0.17273154854774475, 0.00044934506877325475]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0587.jpg\tgoetgevonden dat dese ontbiedinge; bij ons gemeen \t[0.1702859103679657, 0.6514386534690857, 0.17781366407871246, 0.00046176661271601915]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0588.jpg\tschaap harder herwaerts aen te doen; overkomen, ge\t[0.18034836649894714, 0.6388893127441406, 0.18032334744930267, 0.00043900145101360977]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0589.jpg\tmilitie daer in te houden in goede; ordre soo is v\t[0.18125027418136597, 0.6369695663452148, 0.18133307993412018, 0.00044700808939523995]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0590.jpg\tdertig of veertigh persoonen ten; hoogsten; genome\t[0.18298915028572083, 0.6347494125366211, 0.18182864785194397, 0.000432806700700894]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0591.jpg\twillem van outhoorn, wouter; valkenier, abraham va\t[0.17566919326782227, 0.6464359760284424, 0.17746086418628693, 0.0004339509760029614]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0592.jpg\tsijner goet staende maentgelden; en verdere annexe\t[0.17539624869823456, 0.6422619819641113, 0.18191279470920563, 0.0004290082142688334]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0593.jpg\tmaer sijne valsche betigters; en aenklagers tumput\t[0.1796717643737793, 0.6402472853660583, 0.17964474856853485, 0.00043626283877529204]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0594.jpg\taen uwe Edelhedens, niet; demoedig versoeck, dat u\t[0.18268050253391266, 0.6323989033699036, 0.18445061147212982, 0.00046997974277473986]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0595.jpg\tacte van herstellinge en verdere; ten desen dienen\t[0.1756250113248825, 0.6453670859336853, 0.17857380211353302, 0.0004341620078776032]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0596.jpg\ten omme de france vijanden, soo der; eenige quamen\t[0.17520514130592346, 0.6460074186325073, 0.17835259437561035, 0.00043489603558555245]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0597.jpg\tde ridderschap voerende 60. stucken ges:t; waterla\t[0.1699139028787613, 0.6526714563369751, 0.1769840121269226, 0.00043064606143161654]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0598.jpg\tstierlijk pennisten, kranckbesoekers; en chirurgij\t[0.18346057832241058, 0.6341111063957214, 0.18199974298477173, 0.0004285937175154686]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0599.jpg\tvan hier nevens „200.; en uijt 170. Comp:s lijfeij\t[0.17836633324623108, 0.6393428444862366, 0.181844100356102, 0.0004466776445042342]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0600.jpg\tsterck 1662. Coppen, daer onder; gerekent, de oude\t[0.18662512302398682, 0.6306056380271912, 0.18233615159988403, 0.0004330466908868402]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0601.jpg\tbleven met 70. â 80. jnlanders, als; mede ongevaer\t[0.18617424368858337, 0.6294214725494385, 0.18396919965744019, 0.00043505767825990915]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0602.jpg\tsodanig quame te vereijsschen, ende; sonder dat ie\t[0.1880376636981964, 0.6269393563270569, 0.18458417057991028, 0.00043878707219846547]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0603.jpg\tveranderinge ofte bijvoeginge diende; te geschiede\t[0.18781577050685883, 0.6249831914901733, 0.18675817549228668, 0.0004428267711773515]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0604.jpg\tdiscoureren en te verklaren hoe; dat hij bij sig s\t[0.18821433186531067, 0.6157792806625366, 0.19553595781326294, 0.00047040305798873305]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0605.jpg\tquamen overvallen en aentasten:; soo meende sijn E\t[0.1814906895160675, 0.6078569889068604, 0.21020562946796417, 0.00044671815703622997]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0606.jpg\tdeselve niet ten proije mogten werden,; wanneer on\t[0.19786973297595978, 0.5529146790504456, 0.2487141638994217, 0.0005013854242861271]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0607.jpg\tvan meerdere versekeringe mogten; oordelen behoord\t[0.2238064557313919, 0.4795139729976654, 0.2959268093109131, 0.0007527563138864934]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1490_0608.jpg\tvanden Command:r Sijmon vander; stel, en raed aend\t[0.2614988684654236, 0.25724607706069946, 0.48030149936676025, 0.0009535719291307032]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0609.jpg\talthans te deser rhede leggende; zeemagt wel van e\t[0.12676014006137848, 0.6589105129241943, 0.21354921162128448, 0.0007801610045135021]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0610.jpg\tvan het verleden Iaer, als wanneer; volgens het sp\t[0.13482318818569183, 0.682574450969696, 0.18217363953590393, 0.00042872820631600916]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0611.jpg\twas, onaengesien het goet succes; der negotie veel\t[0.13895373046398163, 0.6912961006164551, 0.16935238242149353, 0.0003978185122832656]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0612.jpg\twas getekent; als vooren.; willem van Outhoorn,; w\t[0.14950305223464966, 0.679724931716919, 0.170345738530159, 0.00042626549839042127]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0613.jpg\tdat over de saken van Japan aen; dese tafel wierde\t[0.14787037670612335, 0.678826093673706, 0.17287810146808624, 0.0004254002997186035]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0614.jpg\ttot uijtvindinge van een expedient,; waer door de \t[0.15602198243141174, 0.6718164086341858, 0.17173096537590027, 0.0004306164919398725]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0615.jpg\ten ons buijten postuer te brengen,; om de dierbare\t[0.1552555114030838, 0.6715906262397766, 0.17271915078163147, 0.0004347034264355898]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0616.jpg\ta:o 1684. wierde geordonneert in; haere herwaerts \t[0.15793216228485107, 0.669964075088501, 0.17166566848754883, 0.00043803363223560154]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0617.jpg\trijkelijk te konnen versorgen,; mitsgaders het mis\t[0.15429028868675232, 0.672273576259613, 0.17300088703632355, 0.0004352534015197307]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0618.jpg\tgepractiseert geworden is, sullen; moeten doen hou\t[0.1579713225364685, 0.6694770455360413, 0.17210893332958221, 0.000442577205831185]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0619.jpg\tover te steeken, agtervolgens; sodanige Zeijlaes o\t[0.1638731211423874, 0.6611338257789612, 0.17454060912132263, 0.0004524537653196603]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0620.jpg\tgecarteert legt, maer dat oock de; stronien inde m\t[0.1727645993232727, 0.6496157646179199, 0.17717866599559784, 0.00044093176256865263]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0621.jpg\tde stranen sig veeltijts daer na; reguleeren van g\t[0.17252112925052643, 0.648541271686554, 0.17849688231945038, 0.000440721632912755]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0622.jpg\teen weg is, nu wel eenige jaren; van japan na bata\t[0.17651167511940002, 0.6427064538002014, 0.18035148084163666, 0.00043031980749219656]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0623.jpg\tten zuijden om beoosten de eijlanden; van natuna o\t[0.16779671609401703, 0.6565806269645691, 0.1751844882965088, 0.0004381423641461879]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0624.jpg\tnog een droogte genaemt kleijn; enckhuijser sant, \t[0.16811016201972961, 0.6510683298110962, 0.18039388954639435, 0.00042754184687510133]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0625.jpg\tlange jaren niet voorgevallen is; dat dese coursen\t[0.17321431636810303, 0.6486334800720215, 0.177717387676239, 0.00043489265954121947]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0626.jpg\tvan siam en Toncquin herwaerts; sullen komen, als \t[0.17919635772705078, 0.6368286609649658, 0.18351641297340393, 0.0004584990383591503]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0627.jpg\tvan een hogre prijse als ordinair; te nootsaeken, \t[0.17228758335113525, 0.6498554944992065, 0.17742100358009338, 0.00043590215500444174]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0628.jpg\tals voren. was getekent. . ..; . . . . - Willem va\t[0.1713108867406845, 0.651217520236969, 0.17703872919082642, 0.0004328705254010856]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0629.jpg\tin eenig emploij van onsien kan; werden gebruijckt\t[0.16729460656642914, 0.6544650197029114, 0.17781677842140198, 0.00042358454084023833]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0630.jpg\tvoorde schipper aende Tafel en in het; gebet, eeni\t[0.18193282186985016, 0.6322675943374634, 0.185337632894516, 0.00046197211486287415]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1490_0631.jpg\tBo0; Secrets.; wee; De bovenstaende secrete resolu\t[0.2320868968963623, 0.5498899817466736, 0.21743501722812653, 0.0005880903918296099]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1547_0110.jpg\tgemerkt &E.; Waarmeede; Edele hoog agtbaare gebied\t[0.2211690992116928, 0.5735907554626465, 0.20474472641944885, 0.0004953928873874247]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0111.jpg\tMinuit ola door den P„r gesaghebber ale ander wigl\t[0.21406836807727814, 0.5584779381752014, 0.2269720882177353, 0.00048158192657865584]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1547_0112.jpg\tl  eene heben em maede slekt e ondergeende kopmans\t[0.27044403553009033, 0.46632206439971924, 0.2627047300338745, 0.0005290826666168869]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_8820_0069.jpg\tVan Cormandel deder 24: November ao 1702.; Jck ond\t[0.25601711869239807, 0.5272312164306641, 0.2161468118429184, 0.0006048479117453098]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0070.jpg\tVan Cormandel onder 24: November 1702.; gevonden 6\t[0.2156076431274414, 0.5524832010269165, 0.23144979774951935, 0.00045931784552522004]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0071.jpg\tVan Cormandel onder 24: November 1702.; had geordo\t[0.21742494404315948, 0.546341598033905, 0.2357611507177353, 0.0004722295270767063]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0072.jpg\tVan Cormandel onder 24: November 1702:; Aen den He\t[0.21297387778759003, 0.5346386432647705, 0.25186729431152344, 0.0005201102467253804]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0073.jpg\tVan Cormandel onder 24: November 1702.; gedoente d\t[0.23521912097930908, 0.4637710452079773, 0.30023348331451416, 0.0007763498579151928]\n",
-      "END\tIN\tNL-HaNA_1.04.02_8820_0074.jpg\tVan Cormandel onder 24: November 1702.; soo sal de\t[0.2654220759868622, 0.25423768162727356, 0.4793967008590698, 0.0009435239480808377]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3060_0043.jpg\tNa dat de Leeden deeser Vergaadering bij een geroe\t[0.9717885255813599, 0.010821838863193989, 0.001531894551590085, 0.015857649967074394]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0044.jpg\t\t[0.004722322802990675, 0.9493709206581116, 0.0015321957180276513, 0.04437460005283356]\n",
+      "OUT\tIN\tNL-HaNA_1.04.02_3060_0045.jpg\t\t[0.007382892072200775, 0.4826573133468628, 0.0038950678426772356, 0.5060647130012512]\n",
+      "OUT\tIN\tNL-HaNA_1.04.02_3060_0046.jpg\t\t[0.00460227532312274, 0.07550110667943954, 0.002633779775351286, 0.917262852191925]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0047.jpg\tWoensdag den 13: ' October A„o 1762.; Na dat de Le\t[0.9990507960319519, 0.000773828593082726, 6.256939377635717e-05, 0.00011286102380836383]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0048.jpg\tNagesien; G„s V„n Aken\t[0.0006021875306032598, 0.998832643032074, 0.0005534070078283548, 1.1793497833423316e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0049.jpg\tWoensdag den 13.:' October A„o 1762.; Na dat de Le\t[0.0004429000255186111, 0.9989116191864014, 0.0006400637212209404, 5.48712705494836e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0050.jpg\t\t[0.00018856636597774923, 0.9996403455734253, 0.00016884997603483498, 2.226365950264153e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0051.jpg\tDingsdag Den 2:' November A„o 1762. —; Den Raad bi\t[0.0003259384538978338, 0.9992011189460754, 0.0004702103906311095, 2.7024852897739038e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0052.jpg\tOver te haalen geweest, dan ruijm, een halff Capit\t[0.0003086228098254651, 0.9992207288742065, 0.000468130805529654, 2.5027261472132523e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0053.jpg\tDen bottelier Jan Fredrik Smit, van SHage; Hoffmee\t[0.0003080040623899549, 0.9992508292198181, 0.00043879984878003597, 2.3482602955482434e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0054.jpg\tNagesien; P: D Lahaije\t[0.00034751128987409174, 0.9985083937644958, 0.001141131273470819, 2.927337618530146e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0055.jpg\t\t[7.474747690139338e-05, 0.9997588992118835, 0.00016449566464871168, 1.8904104308603564e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0056.jpg\tNagesien; G: B: D Leeuw; d\t[0.0002799463109113276, 0.9991633892059326, 0.0005544282612390816, 2.249772705908981e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0057.jpg\tMaandag Den 15„e November A„o 1762. —; Het ingedie\t[0.00021810679754707962, 0.9988507032394409, 0.0009280692902393639, 3.1204417609842494e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0058.jpg\t\t[5.8035740948980674e-05, 0.999651312828064, 0.00028814852703362703, 2.5526228455419187e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0059.jpg\tAan den wel Edelen Agtb: Heere; Fredrik Willem Win\t[0.00016706687165424228, 0.999198853969574, 0.000631461851298809, 2.6729103410616517e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0060.jpg\t\t[7.107856799848378e-05, 0.9995469450950623, 0.0003768093592952937, 5.119145498611033e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0061.jpg\t\t[4.72973842988722e-05, 0.9997743964195251, 0.00017536479572299868, 2.9717202778556384e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0062.jpg\tNagesien; J:B: D Leeuw.\t[0.00025144353276118636, 0.999152421951294, 0.0005938347894698381, 2.2149658889247803e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0063.jpg\t\t[4.685004387283698e-05, 0.999716579914093, 0.00023126271844375879, 5.296661129250424e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0064.jpg\t\t[8.079639519564807e-05, 0.9997493624687195, 0.0001671453646849841, 2.706362010940211e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3060_0065.jpg\tE:E: Agtbaaren Heer Johannes Heijnouts; Sondergete\t[0.0006782092386856675, 0.9972317814826965, 0.002083816332742572, 6.235086857486749e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_3060_0066.jpg\tNoering hem daar toe sijne hulpe leenen; Voor 't o\t[0.00011268273374298587, 0.00047187641030177474, 0.9994056224822998, 9.839123777055647e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 73%|███████▎  | 10/13.65625 [00:00<00:00, 15.65batch/s]"
+      " 53%|█████▎    | 6/11.3125 [00:06<00:07,  1.35s/batch]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0075.jpg\tVan Cormandel onder 24: November 1702.; ten dienst\t[0.12715326249599457, 0.6582581996917725, 0.21381030976772308, 0.0007782831089571118]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0076.jpg\tVan Cormandel onder 24: November 1702.; de allermi\t[0.13509301841259003, 0.6820201873779297, 0.18245910108089447, 0.0004277309635654092]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_8820_0077.jpg\tVan Cormandel onder 24: November 1702.; gevolgen, \t[0.13931158185005188, 0.6907104253768921, 0.1695808470249176, 0.0003971432743128389]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_2682_0249.jpg\tMet het ondergenoemde schip; vertrekken over China\t[0.1499280035495758, 0.6791777014732361, 0.17046895623207092, 0.0004253980587236583]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_3095_0015.jpg\tRegister der Papieren; werdende versonden per het \t[0.1480630487203598, 0.6783959865570068, 0.17311644554138184, 0.0004244910378474742]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0016.jpg\t4.; orig: in genaagt, a:o p„o; d'Edele Groot Agtba\t[0.15643933415412903, 0.6712308526039124, 0.1718977987766266, 0.00043212264426983893]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0017.jpg\tN:o 7. Copia Generale Resolutien des Casteels; Bat\t[0.15568934381008148, 0.6708029508590698, 0.17307429015636444, 0.0004333798715379089]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0018.jpg\tCommissien, Memorien,; Jnstructien en z:, welke; v\t[0.15883411467075348, 0.6687590479850769, 0.17196930944919586, 0.00043755071237683296]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0019.jpg\tNo 14. Thien. Gesloten Pacquetten, houdende; de ad\t[0.1550607979297638, 0.6711352467536926, 0.17336830496788025, 0.0004356468853075057]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0020.jpg\tCommissien, Memorien; Jnstructien en z:, weg; van \t[0.1592031568288803, 0.6673834323883057, 0.1729709506034851, 0.00044250430073589087]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0021.jpg\tden Raad ten evengemelde; Gouvernemente aan als; v\t[0.17105688154697418, 0.6478689908981323, 0.18060322105884552, 0.00047090512816794217]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0022.jpg\tBengale zyn vertrokken; zynde dit paquet gelegt; i\t[0.20548203587532043, 0.602337658405304, 0.19162124395370483, 0.0005590973305515945]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0023.jpg\tGouverneur van Malacca; Mr. Thomas Schippers; als \t[0.19437068700790405, 0.6172412037849426, 0.18792995810508728, 0.00045812566531822085]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0024.jpg\tdit berigt nog niet; ingekomen zijnde; zal bij nad\t[0.19107399880886078, 0.6222462058067322, 0.1862439662218094, 0.0004357950820121914]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0025.jpg\tN:o 22. Copia Berigt vande Administra„; teurs inde\t[0.18515357375144958, 0.6321037411689758, 0.1823115050792694, 0.0004312395758461207]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0026.jpg\tde met verscheide scheepen; aangebragte Manufactuu\t[0.18386603891849518, 0.6292756199836731, 0.18642787635326385, 0.0004304127360228449]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0027.jpg\ten 1769. van Cochim overge; sonden, waarbij densel\t[0.1867036521434784, 0.6290291547775269, 0.18383102118968964, 0.0004360829771030694]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0028.jpg\tN:o 28 Drie Copia Berigten van eevengem:; E: Honti\t[0.18838410079479218, 0.6228868365287781, 0.18826015293598175, 0.00046889579971320927]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0029.jpg\tN:o 30 Copia Request door den advocaat M:r Jacob; \t[0.18227174878120422, 0.6345449090003967, 0.18275023996829987, 0.0004331009404268116]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0030.jpg\tsComp:s wapenkamer Reisich; en Expresse gecommitte\t[0.18207743763923645, 0.6349672079086304, 0.1825205534696579, 0.00043478989391587675]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0031.jpg\tN:o 35. Een Exomplaar van het Generaal Re„; 1 glem\t[0.17615853250026703, 0.6423985362052917, 0.18101240694522858, 0.0004305170150473714]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0032.jpg\tN:o 38. Tes origineele; Actens van Indem; & niteil\t[0.18828462064266205, 0.6259459853172302, 0.1853402704000473, 0.0004290625511202961]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0033.jpg\tN:o 40. Vier Turksche Passen vande afgelegde en; v\t[0.18378883600234985, 0.6300652623176575, 0.1857001632452011, 0.00044579184032045305]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0034.jpg\tGeneraalen Eisch van behoeftens uijt; No 44; Neder\t[0.1909637600183487, 0.6230934858322144, 0.18550975620746613, 0.00043296319199725986]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0035.jpg\tN:o 49 Generaal Rendement vande verkogte; 1 onbesc\t[0.19040152430534363, 0.6221733093261719, 0.18699191510677338, 0.0004332413082011044]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0036.jpg\tN: 53. Maandelyksche Restanten inde; groote geldka\t[0.19225645065307617, 0.6197754740715027, 0.18753084540367126, 0.0004372509429231286]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_3095_0037.jpg\tN:o 57: Sommarium van het geladene in tien; Retoúr\t[0.19151991605758667, 0.6181311011314392, 0.18990938365459442, 0.00043958742753602564]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_8260_0061.jpg\tS morgens te agt uuren nog geen bevoeging in het B\t[0.1926615834236145, 0.6071746945381165, 0.1996929794549942, 0.0004707563784904778]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0062.jpg\tinsgelijks een bentings op te werepan, waarop ik h\t[0.18495914340019226, 0.600207507610321, 0.21438847482204437, 0.0004448955587577075]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0063.jpg\tgeschied zynde, goa zig 's morgens te negen uuren \t[0.1996176689863205, 0.5491329431533813, 0.2507488429546356, 0.000500530528370291]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0064.jpg\tverlies van onsekant Heer op mij wederom met den p\t[0.22383636236190796, 0.47764718532562256, 0.2977680265903473, 0.0007484073285013437]\n",
-      "END\tIN\tNL-HaNA_1.04.02_8260_0065.jpg\tIk gaf dierhalven den provisconelen vandrig sor sc\t[0.2629050314426422, 0.25641217827796936, 0.47973302006721497, 0.000949709617998451]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0066.jpg\tvan goa lag, zullende zyn volk zuyd wertwaarts vuu\t[0.1229785904288292, 0.6666591763496399, 0.20954151451587677, 0.0008206904167309403]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0067.jpg\tpligt gadesloeg, ende ordres stijtelijk op gevolgd\t[0.1365281045436859, 0.6778196096420288, 0.1851920634508133, 0.0004602284461725503]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0068.jpg\teyndelijk de banting ook verlaten waar door wij da\t[0.1411125361919403, 0.687727153301239, 0.1707402914762497, 0.00041999699897132814]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0069.jpg\tvagd: den 31 octob 1757; Zatuad„ 1 Nov: 1777; Maan\t[0.15085271000862122, 0.6756444573402405, 0.17304953932762146, 0.00045331960427574813]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0070.jpg\thadden met vorsheid en onder de bedreiging gevraag\t[0.15077148377895355, 0.6760764122009277, 0.1727028787136078, 0.00044922265806235373]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0071.jpg\tDe Heere gouverneur goedgevonden hebbende den post\t[0.1552550494670868, 0.672640323638916, 0.17166076600551605, 0.00044380410690791905]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0072.jpg\tneur addaes seeren moest; vryd. den 21 Noo 1oor De\t[0.16285835206508636, 0.6618435382843018, 0.1748485565185547, 0.0004495923058129847]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0073.jpg\tden ged den 2: Aor 1757; rijst navens een Jnlandse\t[0.1640034019947052, 0.6592527031898499, 0.17625948786735535, 0.00048438480007462204]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0074.jpg\teenige maanden neets anders te hebben gedaan als k\t[0.2275676429271698, 0.560318112373352, 0.21158525347709656, 0.0005290370318107307]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_8260_0075.jpg\tAan den Lieutenant militair Alexander LeCerf; Comm\t[0.20056380331516266, 0.590142011642456, 0.20882321894168854, 0.00047093554167076945]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_3248_0877.jpg\tOp Huijden den 5: October a„o 1761: voor mij Wolfe\t[0.19530409574508667, 0.5871886610984802, 0.21704719960689545, 0.0004600067331921309]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0878.jpg\top die wijze gedurende hun verblijf aldaar, en ond\t[0.20122775435447693, 0.5927642583847046, 0.20557208359241486, 0.00043586702668108046]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0879.jpg\tniet krijgende ! de Xullas aandoen, en overweldige\t[0.19517004489898682, 0.5943316221237183, 0.21005016565322876, 0.00044817852904088795]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0880.jpg\tvan Christoffel dias, en Adriaan Rijkschroef clerc\t[0.1941637396812439, 0.595647931098938, 0.2097603976726532, 0.00042798594222404063]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0881.jpg\tHeden den 8:e Maart 1762: Compareerde voor mij Ioh\t[0.19202375411987305, 0.6021409034729004, 0.20542903244495392, 0.00040633807657286525]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0882.jpg\tdog Een van derzelver prauwen bleeft op de droogte\t[0.19006109237670898, 0.5983905792236328, 0.21112865209579468, 0.00041968695586547256]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0883.jpg\teenige hostiliteijten en moorderijen gepleegt hadd\t[0.1921582818031311, 0.5941954851150513, 0.2131955772638321, 0.00045071050408296287]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0884.jpg\twaar op hij relatant door de papoeers, mits absent\t[0.19367414712905884, 0.589846670627594, 0.21598924696445465, 0.0004899678751826286]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0885.jpg\tanders te zeggen, als 't geen in 't Casteel orange\t[0.1802726835012436, 0.5811598300933838, 0.2380952090024948, 0.0004723060701508075]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0886.jpg\thij relatant in dien zoo wel onder Ambon als Terna\t[0.20362144708633423, 0.5225910544395447, 0.2731133699417114, 0.0006741334800608456]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0887.jpg\tGevende voor redenen van wetenschap als in den tex\t[0.2405497133731842, 0.43609344959259033, 0.32267481088638306, 0.0006821387214586139]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0888.jpg\t\t[0.3414632976055145, 0.29158031940460205, 0.36611562967300415, 0.0008407265413552523]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0889.jpg\tHeden morgen den 23:e April 1765: zont den heer„; \t[0.24137015640735626, 0.5043260455131531, 0.253665030002594, 0.0006388036417774856]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0890.jpg\ten 's konings goetaardigheijt, de wezentlijke oerz\t[0.25276967883110046, 0.45565709471702576, 0.29092663526535034, 0.0006466030608862638]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0891.jpg\tomtrent zij vermeenden nu niets meer te vreezen te\t[0.24014368653297424, 0.32911235094070435, 0.43013495206832886, 0.0006090105744078755]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0892.jpg\t\t[0.29587963223457336, 0.22680158913135529, 0.4765976071357727, 0.0007211209158413112]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0893.jpg\tHeden den 4:e Februarij 1768: Compareerde; voor mi\t[0.2572922110557556, 0.3905166983604431, 0.35152697563171387, 0.000664182472974062]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0894.jpg\tgelegen op 't groot Eijland salwattij vervoert en \t[0.2188585251569748, 0.254109263420105, 0.526413083076477, 0.0006191789289005101]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0895.jpg\t\t[0.3571406304836273, 0.16726776957511902, 0.47488489747047424, 0.0007067376282066107]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0896.jpg\t\t[0.32698139548301697, 0.1743241399526596, 0.49802467226982117, 0.0006697867065668106]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0897.jpg\tOp heden den 4:e Februarij 160: Compareerde voor; \t[0.27060645818710327, 0.41701769828796387, 0.3117138743400574, 0.0006619609775952995]\n",
-      "END\tIN\tNL-HaNA_1.04.02_3248_0898.jpg\tte Batchian ter hou gekomen waren, en zig dien twe\t[0.29076501727104187, 0.22294668853282928, 0.4853399395942688, 0.0009483363828621805]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1088_0511.jpg\tNaer dat den 8en. septembr 1625, het fergatt Surat\t[0.9995299577713013, 0.00038027067785151303, 5.3568310249829665e-05, 3.61987404176034e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0512.jpg\tdie van Lohoe waren hem gevolcht, tot op lebeleeuw\t[0.000736082496587187, 0.998572587966919, 0.0006874403916299343, 3.958030447392957e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0513.jpg\twederom afgesonden, naar Bouro, om te vernemen, wa\t[0.00042865300201810896, 0.9989858269691467, 0.000582914159167558, 2.585274387456593e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0514.jpg\tende ten deele onwillich, soo dat met schoon spree\t[0.00039627691148780286, 0.99903404712677, 0.0005673717241734266, 2.425034153930028e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0515.jpg\tons voor antwoort, dat wel waar was, dat sijn Vade\t[0.0003879569412674755, 0.9990419745445251, 0.0005676839500665665, 2.3906254682515282e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0516.jpg\tnoch al wel toeginck, ende mijn hier van noch vrij\t[0.00037304774741642177, 0.9990683197975159, 0.0005563857848756015, 2.2562601316167274e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0517.jpg\tblijcken wat parthij hij hielt van dese uijr affso\t[0.0003848453634418547, 0.999031662940979, 0.0005811068695038557, 2.431185521345469e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0518.jpg\tdus lange was gedaen, hebben den raet dit in Beden\t[0.0003658614296000451, 0.999068558216095, 0.0005631050444208086, 2.4951484647317557e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0519.jpg\tte mogen werden, met cruijt ende Loot, ende soo he\t[0.000388613116228953, 0.9990730285644531, 0.0005354683962650597, 2.913227945100516e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0520.jpg\tDen 9=en d=o smorgens, quamen voor Oerien, ofte no\t[0.00033083491143770516, 0.9990574717521667, 0.0006093983538448811, 2.32057254834217e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0521.jpg\tmede die van Cabau, den Sergeant aldaer op Hatuha \t[0.00025400155573152006, 0.9991673231124878, 0.0005759106134064496, 2.6939485451293876e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0522.jpg\tSijn voorts doorgepangaijt naer Oma, de corcoiren \t[0.00024546129861846566, 0.9987925291061401, 0.0009588291868567467, 3.1289973776438273e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0523.jpg\t\t[8.456283831037581e-05, 0.9994126558303833, 0.0004990313900634646, 3.7855336358916247e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0524.jpg\t\t[4.827751763514243e-05, 0.9996603727340698, 0.0002867144939955324, 4.662781975639518e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0525.jpg\t\t[3.0766390409553424e-05, 0.9998379945755005, 0.00012662635708693415, 4.588804131344659e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0526.jpg\t\t[5.8023830206366256e-05, 0.9998161196708679, 0.0001114564947783947, 1.4409305549634155e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0527.jpg\t\t[4.426787199918181e-05, 0.999848484992981, 9.675458568381146e-05, 1.049168440658832e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0528.jpg\t\t[4.8987825721269473e-05, 0.9998522996902466, 8.598091517342255e-05, 1.2806456652469933e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0529.jpg\t\t[6.0005735576851293e-05, 0.9998226761817932, 0.00010063667286885902, 1.6681164197507314e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0530.jpg\t\t[5.474875069921836e-05, 0.9998317956924438, 9.496723941992968e-05, 1.841938865254633e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0531.jpg\t\t[9.093455446418375e-05, 0.9997462630271912, 0.0001457376783946529, 1.703287853160873e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0532.jpg\tin Ambonia tsedert 8 septemb.; Daghregister vant g\t[0.0004185232683084905, 0.9988825917243958, 0.0006958474987186491, 3.050959094252903e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0533.jpg\t\t[0.0001893408189062029, 0.9996381998062134, 0.00016916441381908953, 3.3635622003203025e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0534.jpg\tCopien van resolutien tsedert; 21 Julij 1628. tet \t[0.000524799688719213, 0.998666524887085, 0.0008052625344134867, 3.4743839023576584e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0535.jpg\tberockt ons alsoo weder werck, geeft ons de handen\t[0.00047077046474441886, 0.9986982345581055, 0.0008276932057924569, 3.2896382435865235e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0536.jpg\tgewacht, dat sulcx de ongelegentheijt van tijt, en\t[0.000457533955341205, 0.9987055063247681, 0.0008337534964084625, 3.237969167457777e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0537.jpg\tDen 22.en s=o vertrocken van lato ende Holoij, end\t[0.00045695199514739215, 0.9987030029296875, 0.0008367759874090552, 3.2347047635994386e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0538.jpg\tdit geweest sijn, hebben nu inder daatr bevonden, \t[0.0004614722856786102, 0.9986867308616638, 0.0008485791622661054, 3.259247478126781e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0539.jpg\tende gewillich aengenomen, hadden mede al begonnen\t[0.0004731345397885889, 0.9985716342926025, 0.0009519452578388155, 3.2703010219847783e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0540.jpg\tDen 6. H=o Ist fargatt Suratte, Wederom op Amboijn\t[0.0005657071596942842, 0.9982045888900757, 0.0012259373906999826, 3.849762379104504e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0541.jpg\tOuer het Verlies van Rommite, hadden ouer Hittoe, \t[0.0007319174474105239, 0.9970439076423645, 0.0022183102555572987, 5.8309406085754745e-06]\n",
+      "END\tIN\tNL-HaNA_1.04.02_1088_0542.jpg\twaren, het selue achter nelis hoeck te brengen, om\t[0.00012539722956717014, 0.0005359701463021338, 0.9993280172348022, 1.0601354915706906e-05]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 88%|████████▊ | 12/13.65625 [00:00<00:00, 16.48batch/s]"
+      " 62%|██████▏   | 7/11.3125 [00:07<00:05,  1.21s/batch]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0899.jpg\tWaar mede den relatant dit zijne gegevene relaas c\t[0.16347582638263702, 0.5671754479408264, 0.26833581924438477, 0.0010129263391718268]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3248_0900.jpg\t\t[0.404065877199173, 0.30468520522117615, 0.29047891497612, 0.0007700325222685933]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0901.jpg\tOp heden den 8:e Februarij 1768: Compa„; „reerde v\t[0.2528277635574341, 0.5486882328987122, 0.19793754816055298, 0.0005464744754135609]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_3248_0902.jpg\twaar mede den relatant zijn gegevene relaas quam t\t[0.24869173765182495, 0.5353215932846069, 0.21540138125419617, 0.0005852750036865473]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1547_0107.jpg\tExtracten uijt de Daagelijkse Aanteeckeningen, Con\t[0.24311599135398865, 0.5059977769851685, 0.2502225935459137, 0.0006636455073021352]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1547_0108.jpg\top desen holvn en dass: matthijs in ve totenende a\t[0.2662496566772461, 0.4181278347969055, 0.3150073289871216, 0.0006151841371320188]\n",
-      "BEGIN\tOUT\tNL-HaNA_1.04.02_1547_0360.jpg\t\t[0.38792672753334045, 0.2790113687515259, 0.3323174715042114, 0.0007444789516739547]\n",
-      "BEGIN\tOUT\tNL-HaNA_1.04.02_1547_0361.jpg\t\t[0.40287598967552185, 0.27278777956962585, 0.32363441586494446, 0.000701794633641839]\n",
-      "BEGIN\tOUT\tNL-HaNA_1.04.02_1547_0362.jpg\t\t[0.40479233860969543, 0.287615031003952, 0.3069426119327545, 0.0006500289309769869]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1547_0363.jpg\tJnstructie voor den onder„; Sonsbeek, vertreckende\t[0.27019259333610535, 0.5314686298370361, 0.19784635305404663, 0.000492435647174716]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0364.jpg\top te wakkeren sijn, soo meede te Ervaaren wat; Ef\t[0.240231454372406, 0.5416097044944763, 0.2177363783121109, 0.0004224160802550614]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0365.jpg\tVan ons gering vermoogen, voort te setten onder an\t[0.2511919438838959, 0.5443711876869202, 0.20402605831623077, 0.00041078179492615163]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0366.jpg\taanslaagen der picaten en roovers, en des noods; s\t[0.24922041594982147, 0.5441848039627075, 0.20616810023784637, 0.00042663715430535376]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0367.jpg\tgesant Pannejapaija gemaakt, sijn afgehaald; dan g\t[0.2522987127304077, 0.5419290065765381, 0.20534691214561462, 0.0004253606020938605]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0368.jpg\ten hem aanbeveelt om ten uijterken mogelijk den ge\t[0.24825763702392578, 0.5511225461959839, 0.20023828744888306, 0.00038151227636262774]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0369.jpg\tdat sijne regenten een slankxe parthonen; te speel\t[0.2443467080593109, 0.548782229423523, 0.20647618174552917, 0.00039486659807153046]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0370.jpg\tIagthens de Jaager en plathuijs zullen connen; lad\t[0.2504853904247284, 0.5457558035850525, 0.20335087180137634, 0.000407906889449805]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0371.jpg\td'E Comp=es mogte te verrigten wesen, maar; de wij\t[0.25018197298049927, 0.5427674055099487, 0.20661084353923798, 0.0004397702869027853]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1547_0372.jpg\taanbevoolen, en uwE: onder godes geleyjd een; spoe\t[0.24363942444324493, 0.5493484139442444, 0.20662541687488556, 0.0003867594641633332]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_8846_0473.jpg\tVan Cormandel onder dato 27:e 8ber: 1726.; Nederla\t[0.24753443896770477, 0.5396149158477783, 0.21240253746509552, 0.000448106846306473]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8846_0474.jpg\tVan Cormandel onder dato 27=e 8ber: 1726.; der inl\t[0.237867534160614, 0.5460650324821472, 0.2156161665916443, 0.0004513066087383777]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_8846_0475.jpg\tVan Cormandel onder dato 27=e 8ber: 1726.; Agtbaar\t[0.22493045032024384, 0.5238449573516846, 0.25068947672843933, 0.0005351129220798612]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_1083_0013.jpg\tadn. 6=en augustij Anoo 1624; Octe der kerckelijck\t[0.2503430247306824, 0.4232264757156372, 0.3258838653564453, 0.0005466037546284497]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1083_0014.jpg\t\t[0.3541170656681061, 0.28761062026023865, 0.35749247670173645, 0.0007798480219207704]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0015.jpg\tInt Jaer des Heeren onses Salichmaeckers Jesu Chri\t[0.24869343638420105, 0.5304282903671265, 0.22042664885520935, 0.00045158129069022834]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0016.jpg\tKercken dienaers soo te lande als opde; Rhede alhi\t[0.23113231360912323, 0.5328245759010315, 0.23560276627540588, 0.00044036543113179505]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0017.jpg\tVerlost moeten werden midtsgaders offf oock eenige\t[0.21636749804019928, 0.523986279964447, 0.2591531276702881, 0.0004930731956847012]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0018.jpg\tAlsoo de Generale Comp. e. dageluckx boven haer ve\t[0.22251415252685547, 0.45213961601257324, 0.32482847571372986, 0.0005178310675546527]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1083_0019.jpg\tAdvijs vande Kerckelijcke vergaderinge (door orden\t[0.22812868654727936, 0.34043920040130615, 0.43081897497177124, 0.0006130755646154284]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1083_0020.jpg\tArt 1; Om goede ordre inde gemeente Christij te on\t[0.2373349517583847, 0.17322024703025818, 0.5887227058410645, 0.00072209577774629]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1083_0021.jpg\tHantwercx lieden ofte andere die niet gestudeert h\t[0.3095687925815582, 0.14390526711940765, 0.5456234216690063, 0.0009024696773849428]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1083_0022.jpg\tVertrecken ofte andersins eenige veranderingen van\t[0.47273483872413635, 0.10651517659425735, 0.4197530746459961, 0.0009968876838684082]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0023.jpg\ttot een meerder kerckelicke vergaderinghe vereepen\t[0.1267438530921936, 0.6585469245910645, 0.21393071115016937, 0.0007785495254211128]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0024.jpg\tArmen scholen besorcht werden ten laesten offer; y\t[0.13496361672878265, 0.6818667054176331, 0.18274125456809998, 0.0004284452006686479]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0025.jpg\tals de beyaerde persoonen de formeliere vande Inst\t[0.13938528299331665, 0.6905369758605957, 0.16967914998531342, 0.00039859069511294365]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0026.jpg\tDe dienaers sullen alomme soo veel alsmogelyck is \t[0.1506916880607605, 0.6781184077262878, 0.17076247930526733, 0.0004274495877325535]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0027.jpg\tsoo wie hartneckelijcke de vermaninge des kercken;\t[0.14843390882015228, 0.6781166791915894, 0.17302361130714417, 0.0004257345281075686]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0028.jpg\traets der selver ende der naestgelegener gemeente \t[0.15672403573989868, 0.670933187007904, 0.1719101071357727, 0.0004327048663981259]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0029.jpg\tEenige poincten de welcke de kerckelijcke; vergade\t[0.15649959444999695, 0.6698415875434875, 0.17322520911693573, 0.00043355420348234475]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0030.jpg\tSimode gehouden tot dordrecht sess 19. dit sul; in\t[0.1588013619184494, 0.6688539981842041, 0.1719067543745041, 0.00043793636723421514]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0031.jpg\tgevisiteert de plaetse tot opbouwinge der kercken \t[0.15486185252666473, 0.6713660359382629, 0.1733369380235672, 0.00043510860996320844]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0032.jpg\thouden des H: Avondtmaels ende telckens tusschen d\t[0.1586809605360031, 0.6684062480926514, 0.1724713295698166, 0.0004415478906594217]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0033.jpg\tdaer naer met den volcke singht oit wert den kerck\t[0.16479511559009552, 0.6596965193748474, 0.1750565618276596, 0.00045178778236731887]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0034.jpg\tWaer dient een retutatie des Moorsdoms ofte mahune\t[0.17425166070461273, 0.6474534273147583, 0.17785558104515076, 0.00043935823487117887]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0035.jpg\tnaecome volgens de order en vande kercken beraempt\t[0.17393149435520172, 0.6464105248451233, 0.17921841144561768, 0.00043954525608569384]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0036.jpg\tmoeten opseggen; de Schoolmr. moet sorge dragen da\t[0.17918673157691956, 0.6385741233825684, 0.1818091720342636, 0.00042992777889594436]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0037.jpg\tatechismum met sin aenhanghar ondr. Sebast: danck \t[0.17691253125667572, 0.6428461670875549, 0.17980755865573883, 0.00043372646905481815]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0038.jpg\tAlle de Gene die tot noch toe geseten hebben ende \t[0.20262908935546875, 0.601445734500885, 0.1954043060541153, 0.0005208944203332067]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0039.jpg\tleeren lesen schrijven ende in Christelycke deuchd\t[0.20049981772899628, 0.6099770069122314, 0.18907858431339264, 0.00044454846647568047]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0040.jpg\tgelegentheyt der plaetsen door de welcke de andere\t[0.19652719795703888, 0.6102893948554993, 0.19269995391368866, 0.0004834132269024849]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0041.jpg\tCorte, bedenckinge op eenige verhandelde; poincten\t[0.1896388679742813, 0.6228156685829163, 0.18711379170417786, 0.0004316671402193606]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0042.jpg\tWert verstaen de bedieninge vant Sacrament des H; \t[0.189518004655838, 0.6231236457824707, 0.18692056834697723, 0.00043771928176283836]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0043.jpg\tbijde Gecommitteerde wegen de Zinodale Classe; van\t[0.18365614116191864, 0.6306939721107483, 0.1852179765701294, 0.00043188914423808455]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0044.jpg\tOp Appendicx vande kercken ordeninge ten aensien d\t[0.19358593225479126, 0.6172189712524414, 0.1887642741203308, 0.0004308386705815792]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0045.jpg\tInt laeste vandese Schiftelijcke voorstellinge; so\t[0.19087976217269897, 0.6192488670349121, 0.18942320346832275, 0.00044819535105489194]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0046.jpg\tEd: Hr Generael vallende soo is Octob. 23 de ver; \t[0.1961316168308258, 0.6145504117012024, 0.1888827681541443, 0.0004352719697635621]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0047.jpg\tJustus Hurnius, O Sebastianus danckaerts door siec\t[0.1952386498451233, 0.6137292385101318, 0.19059142470359802, 0.0004406470980029553]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1083_0048.jpg\tDes avondts voor het aronsteten is den predicanten\t[0.19688139855861664, 0.611501157283783, 0.19117450714111328, 0.0004428866959642619]\n",
-      "IN\tBEGIN\tNL-HaNA_1.04.02_8696_0051.jpg\tVan Siam onder dato 20: april 1737; Dag-register, \t[0.19678451120853424, 0.6095700860023499, 0.19320029020309448, 0.0004450826963875443]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0052.jpg\tVan Siam onder dato 20:' april 1731; moesten verbl\t[0.19672466814517975, 0.6006214022636414, 0.20218022167682648, 0.0004736868431791663]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0053.jpg\tVan Siam onder dato 20: april 1737; zijn aen gesig\t[0.18965472280979156, 0.5932475328445435, 0.21665093302726746, 0.0004467937396839261]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0054.jpg\tSiam onder dato 2 april 1737; den 8:e _=o alvroeg \t[0.19975076615810394, 0.5499035120010376, 0.24984210729599, 0.0005035650101490319]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0055.jpg\tVan Siam onder dato: 20: april 1737; ons aengewees\t[0.22482094168663025, 0.4781900644302368, 0.29623714089393616, 0.0007518759230151772]\n",
-      "END\tIN\tNL-HaNA_1.04.02_8696_0056.jpg\tVan Siam onder dato: 20: april 1737; Maart; die ge\t[0.26162421703338623, 0.26148125529289246, 0.4759552776813507, 0.0009392626234330237]\n"
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0543.jpg\t244; voorganis, datmen ons niet en mocht vertrouwe\t[0.9996716976165771, 0.0002440052921883762, 5.560545832850039e-05, 2.864483576558996e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0544.jpg\tvrouw, den man niet mede toebehoorde, niet meer an\t[0.0013026803499087691, 0.9975475668907166, 0.0011445655254647136, 5.290075478114886e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0545.jpg\tsoete middelen te werck gaen, hoewel daar mede nie\t[0.000736430985853076, 0.9982445240020752, 0.0010156105272471905, 3.414582806726685e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0546.jpg\tsoude mogen bewaert leggen, maer alst nu alsoo bes\t[0.0006624372908845544, 0.998327910900116, 0.0010065833339467645, 3.124250497421599e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0547.jpg\tsij seijden dat op Hattamana, den Jongen Coninck, \t[0.0006504838238470256, 0.9983435869216919, 0.0010027886601164937, 3.0803296340309316e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0548.jpg\tuijt de quartieren van hittoe, dit heele Mosson, m\t[0.0006729831220582128, 0.9983543157577515, 0.0009696476627141237, 3.129384595013107e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0549.jpg\tdaer van wachten soude, hebben de gevangenen ontsl\t[0.0006439752178266644, 0.9982763528823853, 0.0010766031919047236, 3.1295940061681904e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0550.jpg\thebben geconsenteert, haer best te doen, ende reve\t[0.0006456052651628852, 0.9982292056083679, 0.0011220307787880301, 3.1833753837418044e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0551.jpg\tselffs dootlijck gewont, waar op die van Cambello \t[0.000643562467303127, 0.9981923699378967, 0.0011608133791014552, 3.2136783829628257e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0552.jpg\tspoedich affhandelen, ende ons laeten weeten, waer\t[0.0006327332812361419, 0.9981871247291565, 0.0011769258417189121, 3.1538636449113255e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0553.jpg\tpattij naij, met haer souden afsenden, om den Coni\t[0.0006450952496379614, 0.9981984496116638, 0.0011532953940331936, 3.1781326015334344e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0554.jpg\tbegeerden alleen te verstaen, wat antwoort den kim\t[0.0006323644774965942, 0.9981972575187683, 0.0011673056287690997, 3.137434759992175e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0555.jpg\tsij hadden geseijt voor ons bevreest te weesen, en\t[0.0006447727209888399, 0.9982115030288696, 0.0011405465193092823, 3.1629288059775718e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0556.jpg\tTarnataensen aenhanck, vande custe van Ceram: niet\t[0.0006336785736493766, 0.9982084035873413, 0.0011548417387530208, 3.127799345747917e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0557.jpg\top houden, conde niet bedencken wat Excusien sij d\t[0.0006333737983368337, 0.9982457160949707, 0.0011178076965734363, 3.0894120754965115e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0558.jpg\tvereenichde Nederlanden, maer deselue hebben haren\t[0.0006291400059126318, 0.9981916546821594, 0.0011761009227484465, 3.115921572316438e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0559.jpg\tte werden, het welck wij hebben naergecommen, ende\t[0.0006258258363232017, 0.9981827735900879, 0.00118834909517318, 3.119759185210569e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0560.jpg\ttraecheijt des Conincx van Saulauw, niet en soude \t[0.0006248016143217683, 0.9981860518455505, 0.0011860891245305538, 3.1027441309561254e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0561.jpg\top dat alsoo de oude vruntschap, mocht vernieuwt w\t[0.0006235522450879216, 0.9981833100318909, 0.0011899573728442192, 3.1006238714326173e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0562.jpg\tarmoede die zijn bolck leet, doch ten laetsten hei\t[0.0006269865552894771, 0.9981860518455505, 0.001183861750178039, 3.108519649686059e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0563.jpg\tte assisteeren.; Capn. Hittoe quam ons mede besoec\t[0.0006210214924067259, 0.9981801509857178, 0.0011957986280322075, 3.0843812055536546e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0564.jpg\tHebben den gesant Noffa Maniera, bij ons ontbooden\t[0.0006196658359840512, 0.9981772899627686, 0.0011999757261946797, 3.074886080867145e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0565.jpg\tgoetgevoelen vandese saack; Wij Eijschten vanden g\t[0.0006176775204949081, 0.9981793165206909, 0.001199985621497035, 3.0709593374922406e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0566.jpg\tDit staat ons vreemt aen, connes oock niet geloove\t[0.0006274364423006773, 0.9981719255447388, 0.0011975679080933332, 3.0950491236581e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0567.jpg\tworden, met veel meer schoone woorden daar noch bi\t[0.0006245552212931216, 0.9981446266174316, 0.001227743225172162, 3.108811597485328e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0568.jpg\tnaar Hittoe, aenden ondercoopman vant Nederlants C\t[0.0006667859270237386, 0.9979243278503418, 0.0014055630890652537, 3.372686478542164e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1088_0569.jpg\tdat denselven soude doen translateren, op dat aen \t[0.0009438418201170862, 0.9958733916282654, 0.00317723979242146, 5.5447162594646215e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1088_0570.jpg\tende geen meer en haddent, schreeff Helenij aen on\t[0.00011120597628178075, 0.00034481132752262056, 0.9995362758636475, 7.70642509451136e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "103%|██████████| 14/13.65625 [00:00<00:00, 15.93batch/s]"
+      " 71%|███████   | 8/11.3125 [00:08<00:03,  1.12s/batch]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0057.jpg\tVan Siam onder dato 20: april 1737; vergadert was \t[0.1308359056711197, 0.6738881468772888, 0.1945958137512207, 0.0006801239214837551]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0058.jpg\tVan Siam onder dato: 20: april 1737; Maart voogd v\t[0.12245719879865646, 0.6935535669326782, 0.18355098366737366, 0.0004382397746667266]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0059.jpg\tVan Siam onder dato: 20: april 1737; houden dit go\t[0.1412268877029419, 0.6839978098869324, 0.17438267171382904, 0.0003925894561689347]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0060.jpg\tSiam onder dato: 20: april 1737; an; kittelde en h\t[0.1528184711933136, 0.6743114590644836, 0.17245063185691833, 0.00041942019015550613]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0061.jpg\tVan Siam onder dato: 20:' april 1737; Excuseert, m\t[0.15676839649677277, 0.6717154383659363, 0.1710730344057083, 0.0004431256093084812]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0062.jpg\tan Siam onder dato: 20: april 1737; kittelde en he\t[0.15608811378479004, 0.6699219346046448, 0.17355549335479736, 0.00043446820927783847]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0063.jpg\tVan Siam onder dato: 20=' april 1737; Excuseert, m\t[0.15607145428657532, 0.6712591648101807, 0.17223240435123444, 0.00043693723273463547]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0064.jpg\tSiam onder dato: 20: april 1737; opperhoofd een ro\t[0.15860149264335632, 0.6698997020721436, 0.17104968428611755, 0.0004491464060265571]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0065.jpg\tVan Siam onder dato 20: april 1737; op thee en Con\t[0.16983801126480103, 0.653423547744751, 0.1762995719909668, 0.00043881702004000545]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0066.jpg\tSiam onder dato: 20: april 1737; -; Aan; Maart; te\t[0.1711394488811493, 0.6492423415184021, 0.17917907238006592, 0.00043912691762670875]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0067.jpg\tSiam onder dato: 20: april 1737; N6; an alderhande\t[0.16716787219047546, 0.6573337912559509, 0.17505662143230438, 0.0004417449526954442]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0068.jpg\tSiam onder dato: 20: apr; an; telaeten zien met we\t[0.18082080781459808, 0.6375390887260437, 0.18120408058166504, 0.0004360258753877133]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0069.jpg\tVan Siam onder dato: 29:' april 1737; koraelen van\t[0.1644667088985443, 0.6587917804718018, 0.17626376450061798, 0.0004777166177518666]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0070.jpg\tVan Siam onder dato: 20: april 1737; den 16:e d:o \t[0.17959387600421906, 0.6375470757484436, 0.1824018359184265, 0.000457230256870389]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0071.jpg\tVan Siam onder dato: 20: april 1737; middelpunt te\t[0.1890939325094223, 0.6264989376068115, 0.18393364548683167, 0.00047344109043478966]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0072.jpg\tan Siam onder dato: 20: april 1737; Elders wierd g\t[0.1709858924150467, 0.6214116811752319, 0.20715180039405823, 0.00045059790136292577]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0073.jpg\tVan Siam onder dato: 20: april 1737; te hebben ons\t[0.23080672323703766, 0.5225225687026978, 0.24610145390033722, 0.0005692907725460827]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0074.jpg\tSiam onder dato: 20: april 1737; An; 99; Elders wi\t[0.2087714523077011, 0.5423439145088196, 0.24832576513290405, 0.0005588378407992423]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0075.jpg\tVan Siam onder dato: 20: april 1737; te hebben ons\t[0.2580002248287201, 0.4139590263366699, 0.3274947702884674, 0.0005459398962557316]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0076.jpg\tVan Siam onder dato: 20: april 1737; van hof order\t[0.24737635254859924, 0.44463592767715454, 0.3072328269481659, 0.0007548223366029561]\n",
-      "END\tEND\tNL-HaNA_1.04.02_8696_0077.jpg\tVan Siam onder dato: 20: april 1737; Translaet Sia\t[0.25154754519462585, 0.26024264097213745, 0.4872395098209381, 0.0009702928946353495]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8099_0205.jpg\tVan Ternaten onder dato 11:' 7ber: 1732; van alle \t[0.9996312856674194, 0.0002860643435269594, 5.3606450819643214e-05, 2.9019489375059493e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0206.jpg\tVan Ternaten onder dato 11:' Septemb:r 1732; Lauwt\t[0.0012760489480569959, 0.9975454211235046, 0.0011733275605365634, 5.199290171731263e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0207.jpg\tVan Ternaten onder dato 11:' 7ber: 1732; door hem \t[0.0007270185160450637, 0.99822598695755, 0.0010435982840135694, 3.4044653602904873e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0208.jpg\tTernaten onder dato 11:' 7ber: 1732; Van; „dugting\t[0.0006661674124188721, 0.9983421564102173, 0.000988578307442367, 3.148679070363869e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0209.jpg\tTernaten onder dato 11:' 7ber: 1732; Van; Ternaten\t[0.0006602519424632192, 0.9983484745025635, 0.0009882479207590222, 3.1223669338942273e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0210.jpg\tTernaten onder dato 11:' Sepb: 1732; Van; voor ops\t[0.0006329501629807055, 0.9983215928077698, 0.0010424710344523191, 3.014485400854028e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0211.jpg\tTernaten onder dato 17:' 7ber: 1732; E; Van; en we\t[0.0006278455257415771, 0.9983351826667786, 0.0010340239387005568, 2.9740178888459923e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0212.jpg\tVan Ternaten onder dato 11:' Jber: 1732; Saturdag \t[0.0006291165482252836, 0.9983553290367126, 0.0010125287808477879, 2.9532704957091482e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0213.jpg\tVan Ternaten onder dato 11:' Jber: A„o 1732; AAan \t[0.0006303767440840602, 0.9983378648757935, 0.0010287839686498046, 2.9729740163020324e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0214.jpg\tVan Ternaten onder dato 11:' Septemb: A„o 1732; ee\t[0.0006384073640219867, 0.9982411861419678, 0.0011173522798344493, 3.0961286938691046e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0215.jpg\tVan Ternaten onder dato 11:' Septemb: 1732; waar v\t[0.0006639689090661705, 0.9979673027992249, 0.0013653250643983483, 3.383792318345513e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8099_0216.jpg\tTernaten onder dato 11:' 7ber: A„o 1732; Van; uijt\t[0.0009230943396687508, 0.9954870343208313, 0.003584187012165785, 5.737602805311326e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8099_0217.jpg\tVan Ternaten onder dato 11:' Septemb: 1732; s geli\t[0.00011093446664744988, 0.00034825963666662574, 0.9995331764221191, 7.678319889237173e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 80%|███████▉  | 9/11.3125 [00:08<00:02,  1.08batch/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1070_0199.jpg\t2 saeckers Elck van 3000 lb; 2 halve dittos elck v\t[0.9980164766311646, 0.0011951117776334286, 0.0004300513246562332, 0.00035834635491482913]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1070_0200.jpg\t\t[0.0033359762746840715, 0.9911088943481445, 0.002743801102042198, 0.002811391605064273]\n",
+      "IN\tEND\tNL-HaNA_1.04.02_1070_0201.jpg\tAdriaen gerritsz van utrecht sergiant; marijn Ding\t[0.008283664472401142, 0.8976438045501709, 0.09393522888422012, 0.00013724264863412827]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 88%|████████▊ | 10/11.3125 [00:10<00:01,  1.23s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1509_1538.jpg\tMonsterolle van alle sComp:s Loontreckende; Monste\t[0.9996657371520996, 0.0002513462968636304, 5.458337182062678e-05, 2.8321261197561398e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1539.jpg\tdienaren dewelcke in't Cormandelse Gouvernement bi\t[0.001239656237885356, 0.9975988268852234, 0.0011563834268599749, 5.0744920372380875e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1540.jpg\t339. en 35. persoonen p=r Transport. —; Namen, Toe\t[0.0007339020376093686, 0.9982773065567017, 0.000985415535978973, 3.334223038109485e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1541.jpg\t90; d=o.. . ..; Adsistent; Chirurgijn. . . . ƒ 36.\t[0.0006549559766426682, 0.9983497858047485, 0.0009921861346811056, 3.074438154726522e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1542.jpg\t339 en 74. persoonen P=r Transport; Namen, Toename\t[0.0006838284898549318, 0.9983718991279602, 0.0009412301005795598, 3.1212073281494668e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1543.jpg\tsiekevaar. . . ƒ 20. walcheren. . . . . 1662. Zeel\t[0.0006473595276474953, 0.9983565211296082, 0.000993035384453833, 3.036265070477384e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1544.jpg\t339. en 113. persoonen P=r Transport.; Namen, Toen\t[0.00063288863748312, 0.9983593821525574, 0.001004778896458447, 2.969991783174919e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1545.jpg\tp:l timmerman. ƒ 11. d' bergh China. . . 1682. Ams\t[0.000654469826258719, 0.9983716607093811, 0.0009709415026009083, 3.0092189717834117e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1546.jpg\t339. en 155. persoonen P=r Transport; 1. Abraham f\t[0.0006219803472049534, 0.9983568787574768, 0.0010181806283071637, 2.9162526971049374e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1547.jpg\t90; 90; 90; 90; D=o; d=o; 90; D=o; 90; 90; D=o; D=\t[0.0006546429940499365, 0.9983752965927124, 0.0009670706349425018, 2.977298890982638e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1548.jpg\t339. en 195. persoonen P=r Transport —; Namen, Toe\t[0.0006408162880688906, 0.9983689188957214, 0.0009873026283457875, 2.9449377052515047e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1549.jpg\t90; 90; 90; 40; 90; D=; D=o; D=o; D=o; D=o; D=o; 9\t[0.000621116952970624, 0.9983568787574768, 0.0010191069450229406, 2.9039415494480636e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1550.jpg\t339. en 236. persoonen p=r Transport; Namen, Toena\t[0.0006209887797012925, 0.9983565211296082, 0.0010196373332291842, 2.900132358263363e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1551.jpg\tdo.; 90; do; 90; do; do; 90; 90; 90; D=o. . . . „;\t[0.0006199268973432481, 0.9983583092689514, 0.001018935232423246, 2.899922037613578e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1552.jpg\t339. en 278. persoonen P=r Transport; Namen, Toena\t[0.0006503808544948697, 0.9983755350112915, 0.0009711466846056283, 2.959453922812827e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1553.jpg\tw:t p:r met wat schip in india; presente qualitijt\t[0.0006205200334079564, 0.9983571171760559, 0.0010194774949923158, 2.8985857625229983e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1554.jpg\t339. en 320. persoonen p=r Transport; Namen, Toena\t[0.0006219208589754999, 0.9983585476875305, 0.0010167122818529606, 2.8993031264690217e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1555.jpg\tCommand:r te water en te; noorder Cormandel; „coop\t[0.0006171274580992758, 0.9983555674552917, 0.0010244391160085797, 2.8856841254309984e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1556.jpg\t356. persoonen p=r Transport; Namen toenamen en ge\t[0.0006180928903631866, 0.9983566403388977, 0.0010223871795460582, 2.8807789931306615e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1557.jpg\tw:t p:r met wat schip in jndia..; presente qualiti\t[0.0006177755421958864, 0.9983567595481873, 0.0010225330479443073, 2.8885124265798368e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1558.jpg\t391. persoonen p:r transport; Namen, Toenamen, en \t[0.0006166246021166444, 0.9983578324317932, 0.0010226486483588815, 2.8809390641981736e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1559.jpg\tw:t p:r met wat schip in; presente qualitijt. maen\t[0.0006184214144013822, 0.9983540773391724, 0.0010246264282613993, 2.8859990379714873e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1560.jpg\tNamen Toenamen en Geboorte plaatsen; 1. bastiaan I\t[0.0006180882919579744, 0.9983578324317932, 0.0010212593479081988, 2.88676983473124e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1561.jpg\tw:t p:r met wat schip in jndia/; presente qualitij\t[0.0006156605668365955, 0.9983575940132141, 0.0010238527320325375, 2.8753993319696747e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1562.jpg\t464. persoonen p:r transport; Namen Toenamen en Ge\t[0.0006167965475469828, 0.9983571171760559, 0.0010231551714241505, 2.8833778742409777e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1563.jpg\tp:r coopm: en opperh:t van; tegenep: en p:r novo: \t[0.0006195646128617227, 0.9983536005020142, 0.0010240058181807399, 2.893173586926423e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1564.jpg\t504. persoonen p=r Transport; Namen, Toenamen, en \t[0.0006254959153011441, 0.9983232617378235, 0.0010481951758265495, 2.9282271043484798e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1565.jpg\tw:t p:r met wat schip in; presente qualitijt maent\t[0.00067210040288046, 0.9981207251548767, 0.0012038942659273744, 3.1878291792963864e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1509_1566.jpg\tOp Nagapatnam zijn nogh bescheijden d'volgende; Bo\t[0.0009380431729368865, 0.9964576363563538, 0.0025993590243160725, 5.031526143284282e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1509_1567.jpg\t103 en 84. persoonen p:r transport; 1. toatongoe v\t[0.0001313278917223215, 0.0004021788772661239, 0.9994580149650574, 8.483448254992254e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 11/11.3125 [00:13<00:00,  1.77s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1490_0583.jpg\tCopije Secrete Resolutien; genomen bij de Ho: Rege\t[0.9996656179428101, 0.0002538571716286242, 5.294060247251764e-05, 2.766472243820317e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0584.jpg\tin presentie; van zijn Ed. t te; volbrengen, soo s\t[0.0012668200070038438, 0.9975445866584778, 0.0011833261232823133, 5.190873253013706e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0585.jpg\tdat 's Comp. s dienaren en wel voorna„; mentlijk p\t[0.0007265448803082108, 0.9982732534408569, 0.0009968261001631618, 3.3520634588057874e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0586.jpg\tbij ons te boeck staen voor niet wel; geintentione\t[0.0006719699595123529, 0.9983534812927246, 0.0009714624029584229, 3.1505230708717136e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0587.jpg\tgoetgevonden dat dese ontbiedinge; bij ons gemeen \t[0.0006590731791220605, 0.9983616471290588, 0.0009761892142705619, 3.1130866773310117e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0588.jpg\tschaap harder herwaerts aen te doen; overkomen, ge\t[0.0006577562307938933, 0.9983550906181335, 0.0009840548736974597, 3.1000397484604036e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0589.jpg\tmilitie daer in te houden in goede; ordre soo is v\t[0.0006411481881514192, 0.9983574748039246, 0.000998393865302205, 3.0138292004266987e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0590.jpg\tdertig of veertigh persoonen ten; hoogsten; genome\t[0.0006400620914064348, 0.9983604550361633, 0.0009964691707864404, 3.007888381034718e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0591.jpg\twillem van outhoorn, wouter; valkenier, abraham va\t[0.0006397810648195446, 0.9983595013618469, 0.0009977606823667884, 3.005955932167126e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0592.jpg\tsijner goet staende maentgelden; en verdere annexe\t[0.0006385218002833426, 0.9983605742454529, 0.0009979187743738294, 3.0011240141902817e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0593.jpg\tmaer sijne valsche betigters; en aenklagers tumput\t[0.000645994849037379, 0.9983643889427185, 0.000986626953817904, 3.013062496393104e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0594.jpg\taen uwe Edelhedens, niet; demoedig versoeck, dat u\t[0.0006371470517478883, 0.9983605742454529, 0.0009992739651352167, 2.994636815856211e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0595.jpg\tacte van herstellinge en verdere; ten desen dienen\t[0.0006402351427823305, 0.9983566403388977, 0.001000152318738401, 2.9996699595358223e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0596.jpg\ten omme de france vijanden, soo der; eenige quamen\t[0.0006359116523526609, 0.9983590245246887, 0.0010020154295489192, 2.9870052458136342e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0597.jpg\tde ridderschap voerende 60. stucken ges:t; waterla\t[0.0006360727711580694, 0.9983534812927246, 0.0010074685560539365, 2.9669874948012875e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0598.jpg\tstierlijk pennisten, kranckbesoekers; en chirurgij\t[0.0006283663096837699, 0.9983598589897156, 0.001008728751912713, 2.9394143439276377e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0599.jpg\tvan hier nevens „200.; en uijt 170. Comp:s lijfeij\t[0.0006252375314943492, 0.9983664155006409, 0.0010055446764454246, 2.9153879950172268e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0600.jpg\tsterck 1662. Coppen, daer onder; gerekent, de oude\t[0.0006513104890473187, 0.9983715415000916, 0.0009741550893522799, 2.9891341455368092e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0601.jpg\tbleven met 70. â 80. jnlanders, als; mede ongevaer\t[0.0006280566449277103, 0.9983575940132141, 0.0010113875614479184, 2.9419766178762075e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0602.jpg\tsodanig quame te vereijsschen, ende; sonder dat ie\t[0.0006310389726422727, 0.998358428478241, 0.0010075909085571766, 2.9464631552400533e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0603.jpg\tveranderinge ofte bijvoeginge diende; te geschiede\t[0.0006265107658691704, 0.9983532428741455, 0.0010172664187848568, 2.9217371775303036e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0604.jpg\tdiscoureren en te verklaren hoe; dat hij bij sig s\t[0.0006250430014915764, 0.9983550906181335, 0.0010169099550694227, 2.9288230507518165e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0605.jpg\tquamen overvallen en aentasten:; soo meende sijn E\t[0.0006212848820723593, 0.9983564019203186, 0.0010194826172664762, 2.906475401687203e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0606.jpg\tdeselve niet ten proije mogten werden,; wanneer on\t[0.0006196452886797488, 0.998357355594635, 0.0010200910037383437, 2.898404090956319e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0607.jpg\tvan meerdere versekeringe mogten; oordelen behoord\t[0.000620724109467119, 0.99835604429245, 0.001020309398882091, 2.903130734921433e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0608.jpg\tvanden Command:r Sijmon vander; stel, en raed aend\t[0.000619244878180325, 0.9983580708503723, 0.0010197954252362251, 2.8970518997084582e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0609.jpg\talthans te deser rhede leggende; zeemagt wel van e\t[0.0006209546118043363, 0.9983539581298828, 0.0010222658747807145, 2.901192601711955e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0610.jpg\tvan het verleden Iaer, als wanneer; volgens het sp\t[0.0006279792869463563, 0.998332679271698, 0.0010363407200202346, 2.9264288059493992e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0611.jpg\twas, onaengesien het goet succes; der negotie veel\t[0.0006686467677354813, 0.9981945157051086, 0.0011338115436956286, 3.0664407404401572e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0612.jpg\twas getekent; als vooren.; willem van Outhoorn,; w\t[0.0008010026649571955, 0.9977357387542725, 0.0014596428954973817, 3.6242556689103367e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0613.jpg\tdat over de saken van Japan aen; dese tafel wierde\t[0.0010392291005700827, 0.9963023662567139, 0.0026527675800025463, 5.5267964853555895e-06]\n",
+      "END\tIN\tNL-HaNA_1.04.02_1490_0614.jpg\ttot uijtvindinge van een expedient,; waer door de \t[0.0001319567672908306, 0.0004154530761297792, 0.9994438290596008, 8.69086852617329e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "12batch [00:15,  1.65s/batch]                          "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1490_0615.jpg\ten ons buijten postuer te brengen,; om de dierbare\t[0.9996631145477295, 0.00025345568428747356, 5.472698467201553e-05, 2.8706832381431013e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0616.jpg\ta:o 1684. wierde geordonneert in; haere herwaerts \t[0.0012444094754755497, 0.9975848197937012, 0.0011656596325337887, 5.085044904262759e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0617.jpg\trijkelijk te konnen versorgen,; mitsgaders het mis\t[0.0007251425413414836, 0.9982725381851196, 0.000998975709080696, 3.343217713336344e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0618.jpg\tgepractiseert geworden is, sullen; moeten doen hou\t[0.0006678376812487841, 0.9983385801315308, 0.0009903855388984084, 3.1583035706717055e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0619.jpg\tover te steeken, agtervolgens; sodanige Zeijlaes o\t[0.0006566886440850794, 0.9982996582984924, 0.0010404939530417323, 3.1756430871610064e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0620.jpg\tgecarteert legt, maer dat oock de; stronien inde m\t[0.0006548099918290973, 0.9982233643531799, 0.001118555199354887, 3.1896015570964664e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0621.jpg\tde stranen sig veeltijts daer na; reguleeren van g\t[0.0006491956301033497, 0.9982098340988159, 0.0011378113413229585, 3.2301334158546524e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0622.jpg\teen weg is, nu wel eenige jaren; van japan na bata\t[0.0006489203660748899, 0.9981948733329773, 0.0011529838666319847, 3.243203082092805e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0623.jpg\tten zuijden om beoosten de eijlanden; van natuna o\t[0.0006433538510464132, 0.9981895089149475, 0.0011639344738796353, 3.2173334147955757e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0624.jpg\tnog een droogte genaemt kleijn; enckhuijser sant, \t[0.0006793365464545786, 0.9982150793075562, 0.0011023260885849595, 3.2933630791376345e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0625.jpg\tlange jaren niet voorgevallen is; dat dese coursen\t[0.0006404592422768474, 0.9981909394264221, 0.001165404450148344, 3.1857982776273275e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0626.jpg\tvan siam en Toncquin herwaerts; sullen komen, als \t[0.0006345402216538787, 0.9981821775436401, 0.0011800663778558373, 3.1648241929360665e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0627.jpg\tvan een hogre prijse als ordinair; te nootsaeken, \t[0.0006346344598568976, 0.9981833100318909, 0.001178803388029337, 3.1598758596373955e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0628.jpg\tals voren. was getekent. . ..; . . . . - Willem va\t[0.0006395544041879475, 0.998151957988739, 0.001205200795084238, 3.1904289699014043e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0629.jpg\tin eenig emploij van onsien kan; werden gebruijckt\t[0.0006873567472212017, 0.9979308843612671, 0.0013783191097900271, 3.461678034000215e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0630.jpg\tvoorde schipper aende Tafel en in het; gebet, eeni\t[0.0009467980125918984, 0.9958017468452454, 0.003246003994718194, 5.453542598843342e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1490_0631.jpg\tBo0; Secrets.; wee; De bovenstaende secrete resolu\t[0.0001117201754823327, 0.0003412311489228159, 0.9995393753051758, 7.70781571191037e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "13batch [00:15,  1.31s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0110.jpg\tgemerkt &E.; Waarmeede; Edele hoog agtbaare gebied\t[0.9996683597564697, 0.00023772170243319124, 6.379025580827147e-05, 3.0142153264023364e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0111.jpg\tMinuit ola door den P„r gesaghebber ale ander wigl\t[0.0016885414952412248, 0.9953450560569763, 0.002958133118227124, 8.329462616529781e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0112.jpg\tl  eene heben em maede slekt e ondergeende kopmans\t[0.00012205754319438711, 0.00031572484294883907, 0.9995546936988831, 7.4977456279157195e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "14batch [00:15,  1.00s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8820_0069.jpg\tVan Cormandel deder 24: November ao 1702.; Jck ond\t[0.9996696710586548, 0.00024816161021590233, 5.3943706006975845e-05, 2.814264917105902e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0070.jpg\tVan Cormandel onder 24: November 1702.; gevonden 6\t[0.0012739149387925863, 0.9975729584693909, 0.0011480273678898811, 5.127843905938789e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0071.jpg\tVan Cormandel onder 24: November 1702.; had geordo\t[0.0007494880701415241, 0.9982807636260986, 0.0009664397803135216, 3.3273411190748448e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0072.jpg\tVan Cormandel onder 24: November 1702:; Aen den He\t[0.0006500694435089827, 0.9983468055725098, 0.0010000088950619102, 3.0433000119955977e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0073.jpg\tVan Cormandel onder 24: November 1702.; gedoente d\t[0.0006400021375156939, 0.9983522891998291, 0.0010047731921076775, 3.0109290491964202e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0074.jpg\tVan Cormandel onder 24: November 1702.; soo sal de\t[0.0006451566005125642, 0.9983273148536682, 0.0010244193254038692, 3.0376211270777276e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0075.jpg\tVan Cormandel onder 24: November 1702.; ten dienst\t[0.0006939803133718669, 0.9981359243392944, 0.0011667419457808137, 3.3261733278777683e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8820_0076.jpg\tVan Cormandel onder 24: November 1702.; de allermi\t[0.0009801369160413742, 0.9958691000938416, 0.0031452695839107037, 5.456814960780321e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8820_0077.jpg\tVan Cormandel onder 24: November 1702.; gevolgen, \t[0.0001225833548232913, 0.0003959170717280358, 0.9994732737541199, 8.190352673409507e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "15batch [00:16,  1.22batch/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_2682_0249.jpg\tMet het ondergenoemde schip; vertrekken over China\t[0.9980717897415161, 0.00100780522916466, 0.0007985559059306979, 0.00012173243158031255]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "16batch [00:23,  2.78s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3095_0015.jpg\tRegister der Papieren; werdende versonden per het \t[0.9996663331985474, 0.00024714358733035624, 5.76371603528969e-05, 2.8874936106149107e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0016.jpg\t4.; orig: in genaagt, a:o p„o; d'Edele Groot Agtba\t[0.001223199418745935, 0.997593104839325, 0.0011785266688093543, 5.070771749160485e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0017.jpg\tN:o 7. Copia Generale Resolutien des Casteels; Bat\t[0.0007239365368150175, 0.9982640147209167, 0.0010087478440254927, 3.3508467822684906e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0018.jpg\tCommissien, Memorien,; Jnstructien en z:, welke; v\t[0.0006688731373287737, 0.9983238577842712, 0.0010040155611932278, 3.1686290640209336e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0019.jpg\tNo 14. Thien. Gesloten Pacquetten, houdende; de ad\t[0.0006571879494003952, 0.9983505010604858, 0.0009891919326037169, 3.1126539852266433e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0020.jpg\tCommissien, Memorien; Jnstructien en z:, weg; van \t[0.000654137518722564, 0.9983620047569275, 0.0009807328460738063, 3.0887349566910416e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0021.jpg\tden Raad ten evengemelde; Gouvernemente aan als; v\t[0.0006300818058662117, 0.9983458518981934, 0.0010211337357759476, 2.9517161692638183e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0022.jpg\tBengale zyn vertrokken; zynde dit paquet gelegt; i\t[0.0006266740383580327, 0.9983575940132141, 0.001012682798318565, 2.941516640930786e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0023.jpg\tGouverneur van Malacca; Mr. Thomas Schippers; als \t[0.0006260615191422403, 0.9983388185501099, 0.0010320721194148064, 2.9539201022998895e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0024.jpg\tdit berigt nog niet; ingekomen zijnde; zal bij nad\t[0.0006380101549439132, 0.9983629584312439, 0.000996013288386166, 2.9559894301200984e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0025.jpg\tN:o 22. Copia Berigt vande Administra„; teurs inde\t[0.0006246310658752918, 0.9983581900596619, 0.0010141890961676836, 2.9250443276396254e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0026.jpg\tde met verscheide scheepen; aangebragte Manufactuu\t[0.0006234394968487322, 0.9983590245246887, 0.0010145062115043402, 2.919158532677102e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0027.jpg\ten 1769. van Cochim overge; sonden, waarbij densel\t[0.0006224109674803913, 0.9983538389205933, 0.0010209041647613049, 2.9081786578899482e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0028.jpg\tN:o 28 Drie Copia Berigten van eevengem:; E: Honti\t[0.0006207165424712002, 0.9983552098274231, 0.0010211959015578032, 2.9008285764575703e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0029.jpg\tN:o 30 Copia Request door den advocaat M:r Jacob; \t[0.0006263265968300402, 0.9983614087104797, 0.0010093736927956343, 2.9127859306754544e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0030.jpg\tsComp:s wapenkamer Reisich; en Expresse gecommitte\t[0.000619604776147753, 0.9983559250831604, 0.0010215521324425936, 2.9019347493886016e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0031.jpg\tN:o 35. Een Exomplaar van het Generaal Re„; 1 glem\t[0.0006216022884473205, 0.9983589053153992, 0.0010166752617806196, 2.9052880563540384e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0032.jpg\tN:o 38. Tes origineele; Actens van Indem; & niteil\t[0.0006200880161486566, 0.9983568787574768, 0.0010201653931289911, 2.9012344384682365e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0033.jpg\tN:o 40. Vier Turksche Passen vande afgelegde en; v\t[0.0006214953027665615, 0.998354971408844, 0.0010206407168880105, 2.905681412812555e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0034.jpg\tGeneraalen Eisch van behoeftens uijt; No 44; Neder\t[0.0006247332785278559, 0.9983287453651428, 0.0010435209842398763, 2.935535349024576e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0035.jpg\tN:o 49 Generaal Rendement vande verkogte; 1 onbesc\t[0.0006622809451073408, 0.9981604218482971, 0.001174126984551549, 3.159577545375214e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3095_0036.jpg\tN: 53. Maandelyksche Restanten inde; groote geldka\t[0.0008991407230496407, 0.9968094229698181, 0.0022863915655761957, 5.0018397814710625e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_3095_0037.jpg\tN:o 57: Sommarium van het geladene in tien; Retoúr\t[0.0001341540482826531, 0.0004345295892562717, 0.999422550201416, 8.789587809587829e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "17batch [00:24,  2.23s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8260_0061.jpg\tS morgens te agt uuren nog geen bevoeging in het B\t[0.9996588230133057, 0.0002552396326791495, 5.6450662668794394e-05, 2.949877489299979e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0062.jpg\tinsgelijks een bentings op te werepan, waarop ik h\t[0.0012324214912950993, 0.9976182579994202, 0.0011441261740401387, 5.056373993284069e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0063.jpg\tgeschied zynde, goa zig 's morgens te negen uuren \t[0.0007091356092132628, 0.9982755184173584, 0.0010121166706085205, 3.2632633519824594e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0064.jpg\tverlies van onsekant Heer op mij wederom met den p\t[0.0006529196980409324, 0.9983458518981934, 0.0009981091134250164, 3.0607200187660055e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0065.jpg\tIk gaf dierhalven den provisconelen vandrig sor sc\t[0.0006436578114517033, 0.998359739780426, 0.0009936420246958733, 3.0210069326130906e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0066.jpg\tvan goa lag, zullende zyn volk zuyd wertwaarts vuu\t[0.0006423511076718569, 0.9983603358268738, 0.0009943749755620956, 3.0264532142609823e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0067.jpg\tpligt gadesloeg, ende ordres stijtelijk op gevolgd\t[0.0006398091209121048, 0.9982814788818359, 0.0010757429990917444, 2.927981540779001e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0068.jpg\teyndelijk de banting ook verlaten waar door wij da\t[0.0006296708597801626, 0.9983571171760559, 0.0010101791704073548, 2.9558877940871753e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0069.jpg\tvagd: den 31 octob 1757; Zatuad„ 1 Nov: 1777; Maan\t[0.0006317142397165298, 0.998335063457489, 0.0010302405571565032, 2.9675154564756667e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0070.jpg\thadden met vorsheid en onder de bedreiging gevraag\t[0.0006252776365727186, 0.9982781410217285, 0.0010936630424112082, 3.009861302416539e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0071.jpg\tDe Heere gouverneur goedgevonden hebbende den post\t[0.0006344968569464982, 0.9983128309249878, 0.0010497220791876316, 2.981579200422857e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0072.jpg\tneur addaes seeren moest; vryd. den 21 Noo 1oor De\t[0.0006755624199286103, 0.9981073141098022, 0.001213898416608572, 3.181742386004771e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0073.jpg\tden ged den 2: Aor 1757; rijst navens een Jnlandse\t[0.0008250745013356209, 0.9974762797355652, 0.0016947472468018532, 3.909864062734414e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8260_0074.jpg\teenige maanden neets anders te hebben gedaan als k\t[0.0011982565047219396, 0.9945869445800781, 0.00420792493969202, 6.928751645318698e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8260_0075.jpg\tAan den Lieutenant militair Alexander LeCerf; Comm\t[0.00011157513654325157, 0.0003471864911261946, 0.9995335340499878, 7.767402166791726e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "18batch [00:25,  1.87s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3248_0877.jpg\tOp Huijden den 5: October a„o 1761: voor mij Wolfe\t[0.9996320009231567, 0.0002867208095267415, 4.938192796544172e-05, 3.196508623659611e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0878.jpg\top die wijze gedurende hun verblijf aldaar, en ond\t[0.001041713054291904, 0.9980586171150208, 0.0008950007613748312, 4.679641733673634e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0879.jpg\tniet krijgende ! de Xullas aandoen, en overweldige\t[0.0006033992394804955, 0.9986262321472168, 0.0007672395440749824, 3.0666906241094694e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0880.jpg\tvan Christoffel dias, en Adriaan Rijkschroef clerc\t[0.0005511748022399843, 0.998690664768219, 0.0007553162868134677, 2.8560384635056835e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0881.jpg\tHeden den 8:e Maart 1762: Compareerde voor mij Ioh\t[0.0005697144661098719, 0.9987142086029053, 0.0007132465834729373, 2.879525027310592e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0882.jpg\tdog Een van derzelver prauwen bleeft op de droogte\t[0.0005534894298762083, 0.998711347579956, 0.0007322736782953143, 2.8159558951301733e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0883.jpg\teenige hostiliteijten en moorderijen gepleegt hadd\t[0.0005315798334777355, 0.9986990690231323, 0.0007666207966394722, 2.751178499238449e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0884.jpg\twaar op hij relatant door de papoeers, mits absent\t[0.0005253515555523336, 0.9987032413482666, 0.0007686518947593868, 2.715064510994125e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0885.jpg\tanders te zeggen, als 't geen in 't Casteel orange\t[0.0005246676737442613, 0.9986818432807922, 0.0007907043327577412, 2.6881239136855584e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0886.jpg\thij relatant in dien zoo wel onder Ambon als Terna\t[0.0005455595091916621, 0.9986900687217712, 0.0007616047514602542, 2.7401929401094094e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0887.jpg\tGevende voor redenen van wetenschap als in den tex\t[0.0005269972607493401, 0.9985861778259277, 0.0008841806557029486, 2.5771616947167786e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0888.jpg\t\t[0.0004617199010681361, 0.99873286485672, 0.00080327526666224, 2.091157512040809e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0889.jpg\tHeden morgen den 23:e April 1765: zont den heer„; \t[0.0004745962214656174, 0.998802900314331, 0.0007198433158919215, 2.6311706733395113e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0890.jpg\ten 's konings goetaardigheijt, de wezentlijke oerz\t[0.00046428231871686876, 0.9988126754760742, 0.0007204760331660509, 2.6017896743724123e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0891.jpg\tomtrent zij vermeenden nu niets meer te vreezen te\t[0.0004948658170178533, 0.9985785484313965, 0.0009241001098416746, 2.4571056655986467e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0892.jpg\t\t[0.00031867981306277215, 0.9991738200187683, 0.0005054727080278099, 1.9789638372458285e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0893.jpg\tHeden den 4:e Februarij 1768: Compareerde; voor mi\t[0.0004300725122448057, 0.9987701773643494, 0.000797189655713737, 2.5076935799006606e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0894.jpg\tgelegen op 't groot Eijland salwattij vervoert en \t[0.0004951527807861567, 0.9981460571289062, 0.0013563052052631974, 2.5523279418848688e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0895.jpg\t\t[0.00019082750077359378, 0.9993895292282104, 0.00041762084583751857, 2.0116340238018893e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0896.jpg\t\t[0.00017521920381113887, 0.9995705485343933, 0.0002525212476029992, 1.6441463230876252e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0897.jpg\tOp heden den 4:e Februarij 160: Compareerde voor; \t[0.0004479634517338127, 0.9987395405769348, 0.0008095962693914771, 2.9945965707156574e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0898.jpg\tte Batchian ter hou gekomen waren, en zig dien twe\t[0.0004694670205935836, 0.9987322688102722, 0.0007951332372613251, 3.0624830742453923e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0899.jpg\tWaar mede den relatant dit zijne gegevene relaas c\t[0.000499177083838731, 0.9984733462333679, 0.0010242389980703592, 3.1782651603862178e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0900.jpg\t\t[0.00047722746967338026, 0.997931718826294, 0.0015879261773079634, 3.0549574603355723e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3248_0901.jpg\tOp heden den 8:e Februarij 1768: Compa„; „reerde v\t[0.0007398593006655574, 0.9967026114463806, 0.002552059479057789, 5.509052698471351e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_3248_0902.jpg\twaar mede den relatant zijn gegevene relaas quam t\t[0.00011051086039515212, 0.00041598553070798516, 0.9994648098945618, 8.639186489745043e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0107.jpg\tExtracten uijt de Daagelijkse Aanteeckeningen, Con\t[0.9996719360351562, 0.00018414098303765059, 0.00010387448855908588, 4.000259650638327e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0108.jpg\top desen holvn en dass: matthijs in ve totenende a\t[0.0002052070340141654, 0.0003014642861671746, 0.9994825124740601, 1.080017591448268e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "21batch [00:26,  1.09batch/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0360.jpg\t\t[4.6434310206677765e-05, 2.5492503482382745e-05, 1.813627386582084e-05, 0.9999098777770996]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0361.jpg\t\t[1.5475776308448985e-05, 8.291252925118897e-06, 6.33479203315801e-06, 0.9999698400497437]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0362.jpg\t\t[2.7481732104206458e-05, 1.5985984646249563e-05, 1.1455773346824571e-05, 0.9999450445175171]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0363.jpg\tJnstructie voor den onder„; Sonsbeek, vertreckende\t[0.9995558857917786, 0.00018646824173629284, 3.85285857191775e-05, 0.00021914199169259518]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0364.jpg\top te wakkeren sijn, soo meede te Ervaaren wat; Ef\t[0.002504652366042137, 0.9966664910316467, 0.0007734567625448108, 5.537641845876351e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0365.jpg\tVan ons gering vermoogen, voort te setten onder an\t[0.0008247647783719003, 0.9984316229820251, 0.0007315014954656363, 1.215212614624761e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0366.jpg\taanslaagen der picaten en roovers, en des noods; s\t[0.0005118739209137857, 0.9987766146659851, 0.0007074211025610566, 4.018368144897977e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0367.jpg\tgesant Pannejapaija gemaakt, sijn afgehaald; dan g\t[0.00045651374966837466, 0.9988409876823425, 0.0006995375733822584, 3.011161879840074e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0368.jpg\ten hem aanbeveelt om ten uijterken mogelijk den ge\t[0.00044906220864504576, 0.9988435506820679, 0.0007044600206427276, 2.8988090434722835e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0369.jpg\tdat sijne regenten een slankxe parthonen; te speel\t[0.0004513795138336718, 0.9988102912902832, 0.0007353551918640733, 2.9356237973843236e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0370.jpg\tIagthens de Jaager en plathuijs zullen connen; lad\t[0.00046287011355161667, 0.9986509680747986, 0.0008831138256937265, 3.122991074633319e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0371.jpg\td'E Comp=es mogte te verrigten wesen, maar; de wij\t[0.0006486622733063996, 0.9967778325080872, 0.002568044001236558, 5.455006430565845e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0372.jpg\taanbevoolen, en uwE: onder godes geleyjd een; spoe\t[0.00010998263314832002, 0.0004691403592005372, 0.9994113445281982, 9.502371540293097e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8846_0473.jpg\tVan Cormandel onder dato 27:e 8ber: 1726.; Nederla\t[0.9996780157089233, 0.0002323529333807528, 6.03265616518911e-05, 2.930586379079614e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8846_0474.jpg\tVan Cormandel onder dato 27=e 8ber: 1726.; der inl\t[0.0017240848392248154, 0.9953752160072327, 0.002892346354201436, 8.376827281608712e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8846_0475.jpg\tVan Cormandel onder dato 27=e 8ber: 1726.; Agtbaar\t[0.00012310445890761912, 0.00031795402173884213, 0.9995513558387756, 7.550971076852875e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "23batch [00:29,  1.13s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1083_0013.jpg\tadn. 6=en augustij Anoo 1624; Octe der kerckelijck\t[0.999489426612854, 0.00037690700264647603, 8.722964412299916e-05, 4.6380584535654634e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0014.jpg\t\t[0.006468998268246651, 0.9929623007774353, 0.0003682940441649407, 0.0002003989793593064]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0015.jpg\tInt Jaer des Heeren onses Salichmaeckers Jesu Chri\t[0.002301795408129692, 0.996840238571167, 0.0008491344633512199, 8.752758731134236e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0016.jpg\tKercken dienaers soo te lande als opde; Rhede alhi\t[0.0005745316157117486, 0.9986787438392639, 0.0007434916333295405, 3.1757979286339832e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0017.jpg\tVerlost moeten werden midtsgaders offf oock eenige\t[0.0005185448681004345, 0.9987021684646606, 0.0007762503810226917, 2.94998312710959e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0018.jpg\tAlsoo de Generale Comp. e. dageluckx boven haer ve\t[0.0005135959945619106, 0.9986936450004578, 0.0007897705072537065, 2.926774868683424e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0019.jpg\tAdvijs vande Kerckelijcke vergaderinge (door orden\t[0.0005006034625694156, 0.998701810836792, 0.0007947087869979441, 2.837919964804314e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0020.jpg\tArt 1; Om goede ordre inde gemeente Christij te on\t[0.000499618356116116, 0.9987049102783203, 0.0007926252437755466, 2.830986886692699e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0021.jpg\tHantwercx lieden ofte andere die niet gestudeert h\t[0.0004995114868506789, 0.9987039566040039, 0.0007936035981401801, 2.829575123541872e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0022.jpg\tVertrecken ofte andersins eenige veranderingen van\t[0.0004985055420547724, 0.9987051486968994, 0.0007934898603707552, 2.8246315650903853e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0023.jpg\ttot een meerder kerckelicke vergaderinghe vereepen\t[0.0005042327102273703, 0.9987081289291382, 0.0007847902015782893, 2.8356409984553466e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0024.jpg\tArmen scholen besorcht werden ten laesten offer; y\t[0.0004974631010554731, 0.9987051486968994, 0.0007945378310978413, 2.8187973839521874e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0025.jpg\tals de beyaerde persoonen de formeliere vande Inst\t[0.0004998924559913576, 0.9987020492553711, 0.0007952404557727277, 2.8236072466825135e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0026.jpg\tDe dienaers sullen alomme soo veel alsmogelyck is \t[0.0004965164698660374, 0.9987039566040039, 0.0007966588018462062, 2.8116924113419373e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0027.jpg\tsoo wie hartneckelijcke de vermaninge des kercken;\t[0.0004965902771800756, 0.9986995458602905, 0.0008010820602066815, 2.79268761005369e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0028.jpg\traets der selver ende der naestgelegener gemeente \t[0.000490343663841486, 0.9987045526504517, 0.0008023062837310135, 2.765329782050685e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0029.jpg\tEenige poincten de welcke de kerckelijcke; vergade\t[0.00048802929813973606, 0.9987095594406128, 0.0007996756467036903, 2.742923470577807e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0030.jpg\tSimode gehouden tot dordrecht sess 19. dit sul; in\t[0.0005082749994471669, 0.9987139701843262, 0.0007748546195216477, 2.8119002308812924e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0031.jpg\tgevisiteert de plaetse tot opbouwinge der kercken \t[0.0004902033833786845, 0.9987026453018188, 0.0008044058922678232, 2.7678759124682983e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0032.jpg\thouden des H: Avondtmaels ende telckens tusschen d\t[0.0004924112581647933, 0.9987032413482666, 0.0008015438797883689, 2.771329718598281e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0033.jpg\tdaer naer met den volcke singht oit wert den kerck\t[0.0004889032570645213, 0.9986991882324219, 0.0008091583731584251, 2.74801891464449e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0034.jpg\tWaer dient een retutatie des Moorsdoms ofte mahune\t[0.00048767434782348573, 0.9987004995346069, 0.0008090248447842896, 2.7543642318050843e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0035.jpg\tnaecome volgens de order en vande kercken beraempt\t[0.00048454091302119195, 0.9987013339996338, 0.000811391044408083, 2.73178011411801e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0036.jpg\tmoeten opseggen; de Schoolmr. moet sorge dragen da\t[0.00048317291657440364, 0.9987021684646606, 0.0008119366830214858, 2.7236351343162823e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0037.jpg\tatechismum met sin aenhanghar ondr. Sebast: danck \t[0.0004839519679080695, 0.9987010955810547, 0.0008121808641590178, 2.7275518732494675e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0038.jpg\tAlle de Gene die tot noch toe geseten hebben ende \t[0.0004827906668651849, 0.9987027645111084, 0.0008117486140690744, 2.7222135940974113e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0039.jpg\tleeren lesen schrijven ende in Christelycke deuchd\t[0.0004841367481276393, 0.998699426651001, 0.0008137177210301161, 2.725838839978678e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0040.jpg\tgelegentheyt der plaetsen door de welcke de andere\t[0.0004895331803709269, 0.9986829161643982, 0.0008247890509665012, 2.7491826131154085e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0041.jpg\tCorte, bedenckinge op eenige verhandelde; poincten\t[0.0005203329492360353, 0.9985746145248413, 0.0009021282312460244, 2.8756567189702764e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0042.jpg\tWert verstaen de bedieninge vant Sacrament des H; \t[0.000623463885858655, 0.9982129335403442, 0.0011601283913478255, 3.3944261303986423e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0043.jpg\tbijde Gecommitteerde wegen de Zinodale Classe; van\t[0.0008165809558704495, 0.9970476031303406, 0.0021305617410689592, 5.17204853167641e-06]\n",
+      "END\tIN\tNL-HaNA_1.04.02_1083_0044.jpg\tOp Appendicx vande kercken ordeninge ten aensien d\t[0.0001296506088692695, 0.0005003982805646956, 0.9993603825569153, 9.660720024839975e-06]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1083_0045.jpg\tInt laeste vandese Schiftelijcke voorstellinge; so\t[0.9996755123138428, 0.00024183573259506375, 5.48631142009981e-05, 2.7853617211803794e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0046.jpg\tEd: Hr Generael vallende soo is Octob. 23 de ver; \t[0.0013425718061625957, 0.9972915053367615, 0.0013602792751044035, 5.607696493825642e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1083_0047.jpg\tJustus Hurnius, O Sebastianus danckaerts door siec\t[0.001119152526371181, 0.9960830211639404, 0.002791952108964324, 5.809199137729593e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1083_0048.jpg\tDes avondts voor het aronsteten is den predicanten\t[0.00011469714809209108, 0.0002957984106615186, 0.9995825886726379, 6.894711077620741e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "24batch [00:30,  1.29s/batch]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8696_0051.jpg\tVan Siam onder dato 20: april 1737; Dag-register, \t[0.999670147895813, 0.0002444376586936414, 5.7068929891102016e-05, 2.8394919354468584e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0052.jpg\tVan Siam onder dato 20:' april 1731; moesten verbl\t[0.0013370545348152518, 0.9975607395172119, 0.0010970152216032147, 5.258822511677863e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0053.jpg\tVan Siam onder dato 20: april 1737; zijn aen gesig\t[0.0007060010102577507, 0.9982632994651794, 0.0010274903615936637, 3.2366833693231456e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0054.jpg\tSiam onder dato 2 april 1737; den 8:e _=o alvroeg \t[0.0006481486489064991, 0.9983488321304321, 0.0010000128531828523, 3.0164023883116897e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0055.jpg\tVan Siam onder dato: 20: april 1737; ons aengewees\t[0.0006393356015905738, 0.9983567595481873, 0.0010009024990722537, 3.0001624509168323e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0056.jpg\tVan Siam onder dato: 20: april 1737; Maart; die ge\t[0.000636874872725457, 0.9983591437339783, 0.0010010089026764035, 2.9910390821896726e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0057.jpg\tVan Siam onder dato 20: april 1737; vergadert was \t[0.0006361103733070195, 0.9983586668968201, 0.0010022283531725407, 2.9903987979196245e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0058.jpg\tVan Siam onder dato: 20: april 1737; Maart voogd v\t[0.0006340733380056918, 0.9983593821525574, 0.001003555953502655, 2.9765162707917625e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0059.jpg\tVan Siam onder dato: 20: april 1737; houden dit go\t[0.0006316512590274215, 0.9983568787574768, 0.0010085266549140215, 2.960318852274213e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0060.jpg\tSiam onder dato: 20: april 1737; an; kittelde en h\t[0.0006313940975815058, 0.9983612895011902, 0.0010042975191026926, 2.9419848033285234e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0061.jpg\tVan Siam onder dato: 20:' april 1737; Excuseert, m\t[0.0006212075240910053, 0.9983558058738708, 0.001020123832859099, 2.905534074670868e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0062.jpg\tan Siam onder dato: 20: april 1737; kittelde en he\t[0.0006206798716448247, 0.9983577132225037, 0.0010187646839767694, 2.9037501008133404e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0063.jpg\tVan Siam onder dato: 20=' april 1737; Excuseert, m\t[0.000621096754912287, 0.9983554482460022, 0.0010206052102148533, 2.9039154014753876e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0064.jpg\tSiam onder dato: 20: april 1737; opperhoofd een ro\t[0.0006202600779943168, 0.998357355594635, 0.0010195111390203238, 2.9013215225859312e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0065.jpg\tVan Siam onder dato 20: april 1737; op thee en Con\t[0.0006205941317602992, 0.9983564019203186, 0.0010200762189924717, 2.9026832635281608e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0066.jpg\tSiam onder dato: 20: april 1737; -; Aan; Maart; te\t[0.0006209531566128135, 0.9983554482460022, 0.0010207360610365868, 2.9002260362176457e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0067.jpg\tSiam onder dato: 20: april 1737; N6; an alderhande\t[0.0006203092634677887, 0.9983568787574768, 0.0010199133539572358, 2.9018706300121266e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0068.jpg\tSiam onder dato: 20: apr; an; telaeten zien met we\t[0.0006232424639165401, 0.9983499050140381, 0.0010239380644634366, 2.9159541554690804e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0069.jpg\tVan Siam onder dato: 29:' april 1737; koraelen van\t[0.000619316182564944, 0.9983554482460022, 0.0010223675053566694, 2.89698346023215e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0070.jpg\tVan Siam onder dato: 20: april 1737; den 16:e d:o \t[0.0006296892534010112, 0.9983629584312439, 0.0010043432703241706, 2.919083726737881e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0071.jpg\tVan Siam onder dato: 20: april 1737; middelpunt te\t[0.0006444074679166079, 0.9983673691749573, 0.000985319260507822, 2.942080982393236e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0072.jpg\tan Siam onder dato: 20: april 1737; Elders wierd g\t[0.0006191381835378706, 0.9983527660369873, 0.0010252174688503146, 2.895453917517443e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0073.jpg\tVan Siam onder dato: 20: april 1737; te hebben ons\t[0.0006266593700274825, 0.9983281493186951, 0.001042242394760251, 2.9253412776597543e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0074.jpg\tSiam onder dato: 20: april 1737; An; 99; Elders wi\t[0.000664147490169853, 0.998204231262207, 0.0011285552754998207, 3.0738140139874304e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0075.jpg\tVan Siam onder dato: 20: april 1737; te hebben ons\t[0.0008026157156564295, 0.9976639747619629, 0.0015297934878617525, 3.7259728742355946e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8696_0076.jpg\tVan Siam onder dato: 20: april 1737; van hof order\t[0.001106353709474206, 0.9949514865875244, 0.003935439046472311, 6.783654498576652e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8696_0077.jpg\tVan Siam onder dato: 20: april 1737; Translaet Sia\t[0.00011269961396465078, 0.00034607292036525905, 0.9995334148406982, 7.784056833770592e-06]\n"
      ]
     },
     {
@@ -983,7 +1235,7 @@
     "for batch in tqdm(\n",
     "    test_data.batches(BATCH_SIZE), total=len(test_data) / BATCH_SIZE, unit=\"batch\"\n",
     "):\n",
-    "    predicted = tagger.crf.decode(tagger(batch))\n",
+    "    predicted = tagger(batch)\n",
     "    labels = batch.labels()\n",
     "\n",
     "    _labels = torch.Tensor([label.value for label in labels]).to(int)\n",
@@ -1008,25 +1260,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:tensor([[3]]) classes have zero instances in both the predictions and the ground truth labels. Precision is still logged as zero.\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Metric\tBEGIN\tIN\tEND\tOUT\n",
-      "MulticlassPrecision\t0.0000\t0.8747\t0.0789\t0.0000\n",
-      "MulticlassRecall\t0.0000\t0.8770\t0.1200\t0.0000\n",
-      "MulticlassF1Score\t0.0000\t0.8758\t0.0952\t0.0000\n",
-      "Accuracy (micro average):\t0.7574\n"
+      "MulticlassPrecision\t0.8400\t0.9968\t0.8571\t0.7500\n",
+      "MulticlassRecall\t1.0000\t0.9715\t0.9474\t1.0000\n",
+      "MulticlassF1Score\t0.9130\t0.9840\t0.9000\t0.8571\n",
+      "Accuracy (micro average):\t0.9724\n"
      ]
     }
    ],

--- a/notebooks/page_sequence_tagger_renate.ipynb
+++ b/notebooks/page_sequence_tagger_renate.ipynb
@@ -31,14 +31,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents: 100%|██████████| 78/78 [03:02<00:00,  2.34s/doc]\n"
+      "Writing documents: 0doc [00:00, ?doc/s]\n"
      ]
     }
    ],
@@ -74,25 +74,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents:   0%|          | 0/664 [00:00<?, ?doc/s]"
+      "Writing documents: 0doc [00:00, ?doc/s]"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents:   4%|▍         | 26/664 [00:20<08:26,  1.26doc/s]\n"
+      "Writing documents: 26doc [00:09,  2.66doc/s]\n"
      ]
     }
    ],
    "source": [
+    "import logging\n",
+    "\n",
     "from tqdm import tqdm\n",
     "\n",
     "from document_segmentation.pagexml.annotations.renate_analysis import RenateAnalysisInv\n",
@@ -103,12 +105,17 @@
     "\n",
     "sheet = RenateAnalysisInv(RENATE_ANALYSIS_SHEETS[0])  # TODO: use both sheets\n",
     "\n",
-    "for document in tqdm(sheet.to_documents(n=N), desc=\"Writing documents\", unit=\"doc\"):\n",
+    "for document in tqdm(\n",
+    "    sheet.to_documents(n=N), desc=\"Writing documents\", unit=\"doc\", total=26\n",
+    "):\n",
     "    document_file = RENATE_ANALYSIS_DIR / f\"{document.id}.json\"\n",
     "\n",
-    "    with document_file.open(\"xt\") as f:\n",
-    "        f.write(document.model_dump_json())\n",
-    "        f.write(\"\\n\")"
+    "    if document_file.exists():\n",
+    "        logging.info(f\"Document {document.id} already exists, skipping\")\n",
+    "    else:\n",
+    "        with document_file.open(\"xt\") as f:\n",
+    "            f.write(document.model_dump_json())\n",
+    "            f.write(\"\\n\")"
    ]
   },
   {
@@ -120,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,14 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Reading JSON files: 100%|██████████| 104/104 [00:00<00:00, 152.02file/s]\n"
+      "Reading JSON files: 100%|██████████| 104/104 [00:00<00:00, 176.14file/s]\n"
      ]
     },
     {
@@ -154,7 +161,7 @@
        "2184"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -171,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -183,7 +190,7 @@
        "         <Label.OUT: 3>: 73})"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -194,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -203,7 +210,7 @@
        "[20.8, 1.1446540880503144, 21.623762376237625, 29.513513513513512]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -214,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +233,7 @@
        "         <Label.OUT: 3>: 62})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -240,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -252,7 +259,7 @@
        "         <Label.OUT: 3>: 11})"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -313,7 +320,7 @@
        "'mps'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -344,12 +351,11 @@
        "    (_linear): Linear(in_features=512, out_features=256, bias=True)\n",
        "  )\n",
        "  (_rnn): LSTM(256, 256, num_layers=2, batch_first=True, dropout=0.1, bidirectional=True)\n",
-       "  (_linear): Linear(in_features=512, out_features=4, bias=True)\n",
-       "  (_softmax): Softmax(dim=1)\n",
+       "  (crf): CRF(num_tags=4)\n",
        ")"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -360,181 +366,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/54.59375 [00:00<?, ?batch/s]"
+      "  0%|          | 0/54.59375 [00:01<?, ?batch/s]\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 11.73batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3060 MB\n",
-      "[Loss:\t1.054]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.37batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.085]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.61batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.098]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.21batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.109]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.74batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.116]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.54batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.097]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.56batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.079]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.56batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.054]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:03<00:00, 13.83batch/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.144]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "101%|██████████| 55/54.59375 [00:04<00:00, 13.45batch/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current allocated memory (MPS): 1378 MB\n",
-      "Driver allocated memory (MPS): 3070 MB\n",
-      "[Loss:\t1.250]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+     "ename": "TypeError",
+     "evalue": "CRF.forward() missing 1 required positional argument: 'tags'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[28], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mtagger\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtrain_\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtraining_data\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mEPOCHS\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mBATCH_SIZE\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mWEIGHTS\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mto\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtagger\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_device\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/document_segmentation/model/page_sequence_tagger.py:80\u001b[0m, in \u001b[0;36mPageSequenceTagger.train_\u001b[0;34m(self, pages, epochs, batch_size, weights)\u001b[0m\n\u001b[1;32m     76\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m batch \u001b[38;5;129;01min\u001b[39;00m tqdm(\n\u001b[1;32m     77\u001b[0m     pages\u001b[38;5;241m.\u001b[39mbatches(batch_size), unit\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbatch\u001b[39m\u001b[38;5;124m\"\u001b[39m, total\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mlen\u001b[39m(pages) \u001b[38;5;241m/\u001b[39m batch_size\n\u001b[1;32m     78\u001b[0m ):\n\u001b[1;32m     79\u001b[0m     optimizer\u001b[38;5;241m.\u001b[39mzero_grad()\n\u001b[0;32m---> 80\u001b[0m     outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mbatch\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mto(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_device)\n\u001b[1;32m     81\u001b[0m     \u001b[38;5;66;03m# loss = criterion(outputs, batch.label_tensor().to(self._device)).to(\u001b[39;00m\n\u001b[1;32m     82\u001b[0m     \u001b[38;5;66;03m#     self._device\u001b[39;00m\n\u001b[1;32m     83\u001b[0m     \u001b[38;5;66;03m# )\u001b[39;00m\n\u001b[1;32m     84\u001b[0m     loss \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m-\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcrf(outputs, batch\u001b[38;5;241m.\u001b[39mlabel_tensor()\u001b[38;5;241m.\u001b[39mto(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_device))\n",
+      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1511\u001b[0m, in \u001b[0;36mModule._wrapped_call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1509\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_compiled_call_impl(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)  \u001b[38;5;66;03m# type: ignore[misc]\u001b[39;00m\n\u001b[1;32m   1510\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 1511\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_call_impl\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1520\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1515\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1518\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1519\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1520\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1522\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   1523\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/document_segmentation/model/page_sequence_tagger.py:48\u001b[0m, in \u001b[0;36mPageSequenceTagger.forward\u001b[0;34m(self, pages)\u001b[0m\n\u001b[1;32m     42\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m page_embeddings\u001b[38;5;241m.\u001b[39msize() \u001b[38;5;241m==\u001b[39m (\n\u001b[1;32m     43\u001b[0m     \u001b[38;5;28mlen\u001b[39m(pages),\n\u001b[1;32m     44\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_page_embedding\u001b[38;5;241m.\u001b[39moutput_size,\n\u001b[1;32m     45\u001b[0m ), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBad shape: \u001b[39m\u001b[38;5;124m{\u001b[39m\u001b[38;5;124mpages.size()}\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     47\u001b[0m rnn_out, hidden \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_rnn(page_embeddings)\n\u001b[0;32m---> 48\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcrf\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrnn_out\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     50\u001b[0m output \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_linear(rnn_out)\n\u001b[1;32m     51\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m output\u001b[38;5;241m.\u001b[39msize() \u001b[38;5;241m==\u001b[39m (\u001b[38;5;28mlen\u001b[39m(pages), \u001b[38;5;28mlen\u001b[39m(Label)), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBad shape: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moutput\u001b[38;5;241m.\u001b[39msize()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
+      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1511\u001b[0m, in \u001b[0;36mModule._wrapped_call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1509\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_compiled_call_impl(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)  \u001b[38;5;66;03m# type: ignore[misc]\u001b[39;00m\n\u001b[1;32m   1510\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 1511\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_call_impl\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1520\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1515\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1518\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1519\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1520\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1522\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   1523\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n",
+      "\u001b[0;31mTypeError\u001b[0m: CRF.forward() missing 1 required positional argument: 'tags'"
      ]
     }
    ],
@@ -551,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1127,7 +983,7 @@
     "for batch in tqdm(\n",
     "    test_data.batches(BATCH_SIZE), total=len(test_data) / BATCH_SIZE, unit=\"batch\"\n",
     "):\n",
-    "    predicted = tagger(batch)\n",
+    "    predicted = tagger.crf.decode(tagger(batch))\n",
     "    labels = batch.labels()\n",
     "\n",
     "    _labels = torch.Tensor([label.value for label in labels]).to(int)\n",
@@ -1152,7 +1008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/notebooks/page_sequence_tagger_renate.ipynb
+++ b/notebooks/page_sequence_tagger_renate.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 85,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload now"
@@ -12,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -74,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -88,7 +97,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Writing documents: 100%|██████████| 26/26 [00:10<00:00,  2.55doc/s]\n"
+      "Writing documents: 100%|██████████| 26/26 [00:10<00:00,  2.37doc/s]\n"
      ]
     }
    ],
@@ -127,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,23 +154,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Reading JSON files: 100%|██████████| 104/104 [00:00<00:00, 176.63file/s]\n"
+      "Reading JSON files: 100%|██████████| 104/104 [00:00<00:00, 164.60file/s]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "2184"
+       "104"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,12 +179,14 @@
     "from document_segmentation.model.dataset import DocumentDataset\n",
     "\n",
     "dataset: DocumentDataset = DocumentDataset.from_dir(RENATE_ANALYSIS_DIR)\n",
+    "dataset.shuffle()\n",
+    "\n",
     "len(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +198,7 @@
        "         <Label.OUT: 3>: 73})"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,16 +209,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[20.8, 1.1446540880503144, 21.623762376237625, 29.513513513513512]"
+       "[0.9904761904761905,\n",
+       " 0.05450733752620545,\n",
+       " 1.0297029702970297,\n",
+       " 1.4054054054054055]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,19 +241,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({<Label.IN: 1>: 1591,\n",
+       "Counter({<Label.IN: 1>: 1690,\n",
        "         <Label.BEGIN: 0>: 83,\n",
        "         <Label.END: 2>: 81,\n",
-       "         <Label.OUT: 3>: 67})"
+       "         <Label.OUT: 3>: 72})"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,19 +264,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({<Label.IN: 1>: 316,\n",
+       "Counter({<Label.IN: 1>: 217,\n",
        "         <Label.BEGIN: 0>: 21,\n",
        "         <Label.END: 2>: 19,\n",
-       "         <Label.OUT: 3>: 6})"
+       "         <Label.OUT: 3>: 1})"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,14 +294,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
     "\n",
-    "BATCH_SIZE = 32\n",
-    "EPOCHS = 10\n",
+    "BATCH_SIZE = 64\n",
+    "EPOCHS = 5\n",
     "WEIGHTS = torch.Tensor(dataset.class_weights())  # For an imbalanced dataset"
    ]
   },
@@ -302,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -322,7 +336,7 @@
        "'mps'"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -333,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -358,7 +372,7 @@
        ")"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -369,179 +383,154 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\n",
-      "/Users/carstenschnober/LAHTeR/workspace/document-segmentation/.venv/lib/python3.11/site-packages/tqdm/std.py:636: TqdmWarning: clamping frac to range [0, 1]\n",
-      "116batch [01:44,  1.11batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:17<?, ?file/s]"
+      "100%|██████████| 92/92 [01:10<00:00,  1.30batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2906 MB\n",
-      "[Loss:\t6.392]\n"
+      "[Loss:\t0.520]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:06, 18.18batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:23<?, ?file/s]"
+      "100%|██████████| 92/92 [00:05<00:00, 18.09batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2860 MB\n",
-      "[Loss:\t4.474]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:06, 18.00batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:30<?, ?file/s]"
+      "100%|██████████| 92/92 [00:04<00:00, 18.47batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t4.442]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:06, 19.33batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:36<?, ?file/s]"
+      "100%|██████████| 92/92 [00:04<00:00, 18.64batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t4.433]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:05, 19.72batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:41<?, ?file/s]"
+      "100%|██████████| 92/92 [00:04<00:00, 18.62batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t4.131]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:05, 19.71batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:47<?, ?file/s]"
+      "100%|██████████| 92/92 [00:05<00:00, 18.18batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t3.584]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:05, 19.84batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:53<?, ?file/s]"
+      "100%|██████████| 92/92 [00:05<00:00, 18.19batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t3.574]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:05, 19.80batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [09:59<?, ?file/s]"
+      "100%|██████████| 92/92 [00:04<00:00, 18.48batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t3.569]\n"
+      "[Loss:\t0.515]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:05, 19.60batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [10:05<?, ?file/s]"
+      "100%|██████████| 92/92 [00:04<00:00, 19.07batch/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t3.568]\n"
+      "[Loss:\t0.514]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "116batch [00:05, 19.56batch/s]\n",
-      "Reading JSON files:   0%|          | 0/104 [10:11<?, ?file/s]"
+      "100%|██████████| 92/92 [00:05<00:00, 18.26batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current allocated memory (MPS): 1182 MB\n",
-      "Driver allocated memory (MPS): 2842 MB\n",
-      "[Loss:\t3.567]\n"
+      "[Loss:\t0.514]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -558,16 +547,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Reading JSON files:   0%|          | 0/104 [10:23<?, ?file/s]\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -579,622 +561,610 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 18%|█▊        | 2/11.3125 [00:00<00:03,  2.72batch/s]"
+      "  4%|▍         | 1/24 [00:00<00:04,  5.53batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1060_0435.jpg\tAlsoo het schip der Goes, als t'Jacht Cleijn Enckh\t[0.9996637105941772, 0.0002524361771065742, 5.55374936084263e-05, 2.8267319066799246e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0436.jpg\tOp heden den 5 feb. @ 1614, door beroep vanden E. \t[0.0012747891014441848, 0.997553288936615, 0.0011668851366266608, 5.150438937562285e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0437.jpg\t@ 1615. Dondergeschreven te soonen; Soo Is bij d' \t[0.0007243358995765448, 0.9982724189758301, 0.0009999239118769765, 3.3418723432987463e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0438.jpg\tDen 19 feb. . vernomen hebbende op de factorije to\t[0.0006676050252281129, 0.9983349442481995, 0.0009944145567715168, 3.1268480142898625e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0439.jpg\tErt Dircx wttgevaren voor Soldaet, opt schip Banta\t[0.0006568318349309266, 0.9983606934547424, 0.000979323056526482, 3.1010447401058627e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0440.jpg\tComptoir deeart sullen gaen, omme door den opperco\t[0.0006553619750775397, 0.9983624815940857, 0.0009790909243747592, 3.096177124461974e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0441.jpg\tAl500. Anthonij Caen, getrout met Jannetien Gillis\t[0.0006557885790243745, 0.9983627200126648, 0.0009783399291336536, 3.096124828516622e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0442.jpg\tssouden mogen geraecken, &ne ten derden vermits al\t[0.0006503397016786039, 0.9983595013618469, 0.0009869943605735898, 3.0627386422565905e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0443.jpg\tAlsoo tot noch toe geen schepen wt het vaderlant, \t[0.0006529833772219718, 0.9983555674552917, 0.000988348270766437, 3.0696569410793018e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0444.jpg\tNaerder gelet sijnde, volgens apostile door d Ed. \t[0.0006359292892739177, 0.9983248114585876, 0.001036216039210558, 3.0179642180883093e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0445.jpg\t@ 1615; E; Den 14e. septemb. d'onderges raden, opt\t[0.0006385945598594844, 0.9982671737670898, 0.0010911064455285668, 3.07789468934061e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0446.jpg\tge; Alsoo 'T schip Esterre, tot zijnne te doene vo\t[0.0006711218156851828, 0.9979767203330994, 0.0013488966505974531, 3.373667823325377e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1060_0447.jpg\tMaendach den xiiije Decemb. @ 1615 &; Alsoo bij de\t[0.0008880437817424536, 0.9964327812194824, 0.0026738967280834913, 5.252621122053824e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1060_0448.jpg\tSivert Sipkens sargeant die de voors compe. tot nu\t[0.00011219384032301605, 0.00034786525066010654, 0.9995321035385132, 7.816047400410753e-06]\n",
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1066_0065.jpg\tNo. 1— Originelen missive door d' H=r Presidt Cocn\t[0.9980794191360474, 0.0010041077621281147, 0.0007949898717924953, 0.00012147149391239509]\n"
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0430.jpg\t\t[0.00023680477170273662, 0.0006503228796645999, 0.00011872695904457942, 0.9989941716194153]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0431.jpg\tMondelingh Berigt ge„; „daen door den E: Cop=n; 1;\t[0.9998762607574463, 6.241842493182048e-05, 3.1839925213716924e-05, 2.9442173399729654e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0432.jpg\tEn motiven wat uijt d' verweijderingen tusschen; d\t[0.002645435044541955, 0.9959866404533386, 0.0009351801709271967, 0.0004327444767113775]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0433.jpg\thet geheele gebret van het Land van Elledetta„; „s\t[0.0004950308357365429, 0.9990591406822205, 0.0003787148161791265, 6.719260272802785e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0434.jpg\tvant perisolisehe Rijck, zijn h:r den ragia; van c\t[0.0002472178020980209, 0.9994496703147888, 0.0002673076814971864, 3.573816502466798e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0435.jpg\tBetuijginge: bij haer hoogh=t wierde, versogt te; \t[0.00018776272190734744, 0.999562680721283, 0.0002247396914754063, 2.476193731126841e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0436.jpg\tmissoeijen zijn h=t weder na zin voorige; Resident\t[0.00019598861399572343, 0.9995716214179993, 0.00020785686501767486, 2.4596889488748275e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0437.jpg\ten haer h=t kwam selffs ook met Een groote; macht \t[0.00014169540372677147, 0.9996100068092346, 0.00022649425955023617, 2.185824268963188e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0438.jpg\t2 h:t den; hadden Bij Eerste gelegenth=t zijn ^ oo\t[0.00016686769959051162, 0.9995763897895813, 0.0002341171057196334, 2.260198198200669e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0439.jpg\tnu mede aen d' kant van tesancoor was; off gecomen\t[0.00014738598838448524, 0.9996127486228943, 0.0002176909038098529, 2.2160489606903866e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0440.jpg\ttoegevinge; corressen, gisen, nogh drijgge„; „ment\t[0.0001431621058145538, 0.9996472597122192, 0.0001878576003946364, 2.1733530957135372e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0441.jpg\ten dewijl alle dagen een Commissaris; een Command:\t[0.00015190543490462005, 0.9995998740196228, 0.00022438076848629862, 2.3782322386978194e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0442.jpg\tvan d E Comp:e, met verdere Bijvoeginge dat; zijn \t[0.00014975712110754102, 0.9995880722999573, 0.00024125416530296206, 2.1008763724239543e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0443.jpg\twijnige tijk door een duijster woerhige zijn; glan\t[0.00015792236081324518, 0.9995962977409363, 0.0002252252888865769, 2.0578590920194983e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0444.jpg\tuijt sulx ontsloot, want het land em de; coopl: wa\t[0.00013799099542666227, 0.9996222257614136, 0.00021911703515797853, 2.0628191123250872e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0445.jpg\tvan d' teruntschap Jongst Eenige bluijckerije; In \t[0.00016201392281800508, 0.9996041655540466, 0.00021059985738247633, 2.3267599317478016e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0446.jpg\tdoese Is moten doen om te Leten, Iwage; dat den Co\t[0.00015185541997198015, 0.9996194839477539, 0.000207376157050021, 2.119735836458858e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0447.jpg\tLoedoart tot manapaer haer verbooden, eenige; nego\t[0.00013306351320352405, 0.9996230602264404, 0.0002252463746117428, 1.8581778931547888e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0448.jpg\tvan des E Comp:s regotie, war op het selve antrus;\t[0.00014798346091993153, 0.999575674533844, 0.0002527312026359141, 2.3642964151804335e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0449.jpg\tdoer bij souden voegen, seer op konden te; 6; Besw\t[0.00017318235768470913, 0.9995793700218201, 0.00022252921189647168, 2.492119892849587e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0450.jpg\tkennisse van boosen te nemen, zoo hebbenske; hun b\t[0.0001447670510970056, 0.9996156692504883, 0.00021877943072468042, 2.074253097816836e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0451.jpg\tontrent dese onderhandelinge, meer end' meer; te b\t[0.00013762508751824498, 0.9995859265327454, 0.0002544884628150612, 2.1929648937657475e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0452.jpg\tder vreede sonder hem te doen geven de ge„; Requin\t[0.0001574214838910848, 0.9995933175086975, 0.00022879843891132623, 2.0545585357467644e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0453.jpg\tdoen over seer onvergenoegt, en daer op geresoldee\t[0.00013521526125259697, 0.9995055198669434, 0.0003355259250383824, 2.3669392248848453e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0454.jpg\thelpen seszertigen en ook niet soo dwaar Jon; wese\t[0.00022366280609276146, 0.9973587393760681, 0.0023803345393389463, 3.727084185811691e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0455.jpg\tverbreekende den voornoem fronsuer heer; als oijne\t[3.425911199883558e-05, 0.0001874463341664523, 0.9997749924659729, 3.379386043889099e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8596_0761.jpg\tVan Malacca onder dato 22„e Janu: 1709: —; Extract\t[0.9999228715896606, 5.747918476117775e-05, 1.750862611515913e-05, 2.1780870156362653e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8596_0762.jpg\tVan Malacca onder dato 22„e Janu: 1709; man die bi\t[0.0008915380458347499, 0.9985802173614502, 0.00045334972674027085, 7.482878572773188e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8596_0763.jpg\tVan Malacca, onder dato 22„e Janu: 1709:; over atc\t[0.0002601172018330544, 0.9994339346885681, 0.00027710205176845193, 2.8859221856691875e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8596_0764.jpg\tVan Malacca onder dato 22„e Janu: 1709:; ter selve\t[0.00019505630189087242, 0.999473512172699, 0.0003077995788771659, 2.3652273739571683e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8596_0765.jpg\tVan Malacca onder dato 22„e Janu: 1709:; den EE: h\t[0.00023561176203656942, 0.9977983236312866, 0.0019342959858477116, 3.1746705644764006e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8596_0766.jpg\tVan Malacca onder dato 22„e Janu: 1709:; de sterck\t[3.2504041882930323e-05, 0.00017964727885555476, 0.9997850060462952, 2.786491677397862e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 27%|██▋       | 3/11.3125 [00:01<00:03,  2.38batch/s]"
+      " 21%|██        | 5/24 [00:00<00:02,  6.80batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0348.jpg\t\t[3.767828457057476e-05, 1.168915241578361e-05, 1.6890284314285964e-05, 0.9999337196350098]\n",
-      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0349.jpg\t\t[1.3423024938674644e-05, 5.066107860329794e-06, 6.1292248574318364e-06, 0.9999754428863525]\n",
-      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0350.jpg\t\t[2.89409035758581e-05, 1.1263072337897029e-05, 1.1508109309943393e-05, 0.9999483823776245]\n",
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0351.jpg\tTranslaat ola door haar E:; heer Commandeur adriaa\t[0.9994751811027527, 0.00016204184794332832, 5.188388240640052e-05, 0.0003109582175966352]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0352.jpg\tgegeven werd op dit alle onlusten verweijderinghe \t[0.002426056656986475, 0.9959057569503784, 0.0015960998134687543, 7.202728738775477e-05]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1547_0353.jpg\ten het Cochinisz rijk herwaarts te senden om over \t[0.0002140397991752252, 0.0006525940843857825, 0.9990953207015991, 3.8060639781178907e-05]\n"
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0614.jpg\t\t[0.0001189231697935611, 0.00040132092544808984, 4.494664608500898e-05, 0.9994348883628845]\n",
+      "OUT\tBEGIN\tNL-HaNA_1.04.02_1547_0615.jpg\t\t[4.286131661501713e-05, 8.152954978868365e-05, 2.2358128262567334e-05, 0.999853253364563]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1547_0616.jpg\t1: de weduwe van Cornelis verdonck zal=r - - - - -\t[0.9996368885040283, 7.999297667993233e-05, 5.104193769511767e-05, 0.00023214492830447853]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0617.jpg\tgeruwde Persoonen met haare familjen,; anur Adriaa\t[0.011218822561204433, 0.9818529486656189, 0.002009269082918763, 0.004918962717056274]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0618.jpg\t26. huijs gesinnen Naamen toenamen - - - - - - - -\t[0.0015154351713135839, 0.9976119995117188, 0.0006167812971398234, 0.0002557664120104164]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0619.jpg\tP„r Transport Copper : 348. —; 1: - - - - - - - - \t[0.00031454244162887335, 0.9993447661399841, 0.00028837512945756316, 5.231601244304329e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0620.jpg\t54 huijsgesinnen Namen - - - - - - - - - - - - - -\t[0.0001730702060740441, 0.9995419979095459, 0.00025735548115335405, 2.7692076400853693e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0621.jpg\t„r Transport Coppen. —. 591.; 1. 3 5. . . . . . . \t[0.0001797497970983386, 0.9995457530021667, 0.000245692121097818, 2.8831776944571175e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0622.jpg\t8 6. huijsgesinnen namen toenamen - - - - - - - - \t[0.0001657187385717407, 0.9995622038841248, 0.0002464130229782313, 2.559519089118112e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0623.jpg\t1 1. - - - - - - - - - - - - - - - - - - - - - - -\t[0.0001550109009258449, 0.9995924830436707, 0.00022797776910010725, 2.451962063787505e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0624.jpg\t1. de weduwe van balten Cannemans. - . . . . . . C\t[0.0001551731547806412, 0.9996200799942017, 0.0001995248458115384, 2.5173245376208797e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0625.jpg\t=Transport Coppen 952. —; 1. 1. 1. . . . . . . . .\t[0.00015715892368461937, 0.9995825886726379, 0.00023421189689543098, 2.605890949780587e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0626.jpg\t150. huijsgesinnen Naamen toenaamen; Europiaanse m\t[0.00015898940910119563, 0.999584972858429, 0.00023144649458117783, 2.45811534114182e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0627.jpg\tP„r Transport Coppen. . 1128. —; naet soons doeket\t[0.0001498389319749549, 0.9996107220649719, 0.00021476909751072526, 2.4629140170873143e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0628.jpg\thuijsgesinnen Naamen - - - - - - - - - - - - - - -\t[0.00013358553405851126, 0.9996083378791809, 0.0002323218941455707, 2.5724040824570693e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0629.jpg\tP„r Transport Coppen —. 1260. —; moeder vrouwen li\t[0.00013752721133641899, 0.9996154308319092, 0.00022422298206947744, 2.2784377506468445e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0630.jpg\t176 huijsgesinnen Naamen; 1. weduwe van pauel borg\t[0.00014125606685411185, 0.9995754361152649, 0.00025712756905704737, 2.626951754791662e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0631.jpg\tP„r Transport Coppen. - 1394. —; moeder vouwen lin\t[0.0001455113524571061, 0.9996073842048645, 0.00022013590205460787, 2.710346416279208e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0632.jpg\t205. huijsgesinnen naamen; 1. francisco alves. - -\t[0.0001345469063380733, 0.9996019005775452, 0.00024080442381091416, 2.280391527165193e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0633.jpg\tP=r Transport Coppen. 1538. —; ::; mans múren, Soo\t[0.00018124667985830456, 0.9995200634002686, 0.00026994862128049135, 2.872189179470297e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0634.jpg\t1. pasquaal d' Croes. - ..; 1. Isaak Leraan van ba\t[0.00014702290354762226, 0.9995790123939514, 0.00024925480829551816, 2.4639635739731602e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0635.jpg\tDoor Voordragt Coppen 1663; 1. 5. —; 1.; 1. . . . \t[0.0001345339696854353, 0.9995181560516357, 0.00032075418857857585, 2.658223638718482e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0636.jpg\t259. huijsgesinnen Naamen; _o; 1. anjela dunies-; \t[0.00022099762281868607, 0.9967189431190491, 0.00301178521476686, 4.826578515348956e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0637.jpg\tmangvrou, soons, dogters, susters, broeder, schoon\t[2.907001726271119e-05, 0.00016271437925752252, 0.9998050332069397, 3.134750841127243e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3589_0657.jpg\tExtract uijt de Gehoudene; aantekening door den Op\t[0.9998883008956909, 8.679385791765526e-05, 2.2449996322393417e-05, 2.47865796154656e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0658.jpg\tantwoord als eenvoudig, Ja of en een, mede; te bre\t[0.0011596046388149261, 0.9982404708862305, 0.0005239630700089037, 7.590634049847722e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0659.jpg\theen te gaan, dog toen wierd hij nog; meer verleeg\t[0.00022658372472506016, 0.9994794726371765, 0.000267906958470121, 2.6108629754162394e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0660.jpg\tkelijk was, zig over dat geval niet ab„; leen zeer\t[0.00021025862952228636, 0.9995361566543579, 0.00023144378792494535, 2.2129817807581276e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0661.jpg\tden 30 jJanuorij Donderdag zond lij de ordinarie A\t[0.0001841401244746521, 0.9995967745780945, 0.00019946994143538177, 1.968838660104666e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0662.jpg\tkelijk was, tig over dat geval niet; leen zeer ge-\t[0.00017228680371772498, 0.9995904564857483, 0.000217804015846923, 1.9398483345867135e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0663.jpg\tden 30 januorij Donderdag zond lij de ordinare Age\t[0.0001651485508773476, 0.9995487332344055, 0.00026622641598805785, 1.9876964870491065e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0664.jpg\tonverkogt bleef legge, doordien de; Paleatcherijse\t[0.00017085055878851563, 0.9995781779289246, 0.00023282899928744882, 1.8094002371071838e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0665.jpg\touden gang hebben gegaan; hoe zij„; ho:t 't zedert\t[0.00016039553156588227, 0.9996116757392883, 0.00020852494344580919, 1.9425517166382633e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0666.jpg\timmers zelfs kon verbieden om in onze; pagterijen \t[0.00015421395073644817, 0.9996200799942017, 0.00020779597980435938, 1.785496533557307e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0667.jpg\tkopen, en zulks hadde willen beletten, door; „hun;\t[0.0001923588861245662, 0.9995909333229065, 0.00019756387337110937, 1.9170536688761786e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0668.jpg\tcasche wijse tabak op de eene of andere; wijze zel\t[0.00018361455295234919, 0.9995908141136169, 0.00020539412798825651, 2.009813761105761e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0669.jpg\topzigt voor zig gehoopt en verwagt had,; bij zijn \t[0.00016683602007105947, 0.9995905756950378, 0.00022427555813919753, 1.8367938537267037e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0670.jpg\toneenigheijd afschildende, even eens als; of zijn \t[0.00017323407519143075, 0.9995852112770081, 0.00022169995645526797, 1.9920445993193425e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0671.jpg\tden 20 februarij Dingsdag liet zijn wel Ed: Agtb: \t[0.00017051598115358502, 0.9994738698005676, 0.0003347429446876049, 2.0807419787161052e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3589_0672.jpg\tgens aan zijne zijde, het geval omtrend; zo eenen \t[0.00028895208379253745, 0.9976970553398132, 0.001983575290068984, 3.0452565624727868e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_3589_0673.jpg\ten borg te dragen, dat hij zo inden verkoop; van z\t[3.44669351761695e-05, 0.0001718446146696806, 0.9997909665107727, 2.7923447305511218e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1188_0433.jpg\tDecembr. 1651. In't schip den Drommedaris; Daghreg\t[0.9998942613601685, 8.502013224642724e-05, 1.8341866962146014e-05, 2.378815906922682e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0434.jpg\tDecemb. 1651. In't schip den Drommedaris; weijnigh\t[0.0010639462852850556, 0.9983692765235901, 0.00048524324665777385, 8.146982145262882e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0435.jpg\tDecemb. 1651 In't schip den Drommedavis.; Omtrent \t[0.00028434928390197456, 0.9994383454322815, 0.0002494259097147733, 2.790839789668098e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0436.jpg\tDecemb. 1651. In't schip den Drommedaris.; 25=en p\t[0.00019825327035505325, 0.9995514750480652, 0.0002272466808790341, 2.2955304302740842e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0437.jpg\tDecemb. 1651. In't schip den Drommedadris; heen, I\t[0.00022811318922322243, 0.9995101690292358, 0.00023881766537670046, 2.28630979108857e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0438.jpg\tDecemb: 1651.; In't schip den Rremmedaris; Officie\t[0.00019220422836951911, 0.9995704293251038, 0.00021569395903497934, 2.1668782210326754e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0439.jpg\tJanuario Ao. 1652. In't schip den Drommedaris; Adi\t[0.00015711062587797642, 0.9996271133422852, 0.00019572957535274327, 2.007457624131348e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0440.jpg\tJanuarij 1652.; In't schip den Drommedaris; int af\t[0.00019128712301608175, 0.9995597004890442, 0.00022788377827964723, 2.109483648382593e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0441.jpg\tIn't schip den Drommedaris 196; met het bequaeme w\t[0.00015319956582970917, 0.9996181726455688, 0.00021186649973969907, 1.6739404600230046e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0442.jpg\tJanuarij 1652. In't schip den Drommedavis; 10=e d=\t[0.0001781304890755564, 0.9995724558830261, 0.00023305560171138495, 1.6334368410753086e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0443.jpg\tJanuarij 1652.; In't schip den Drommedaris.; Savon\t[0.00015886148321442306, 0.999617338180542, 0.00020614844106603414, 1.76579924300313e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0444.jpg\tJanuarij 1652. In't schip den Drommedaris; sulcx d\t[0.00016756102559156716, 0.9995942711830139, 0.00021901773288846016, 1.918922134791501e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0445.jpg\tJanuarij 1652.; In't schip den Drommedaris.; 23=e \t[0.0001673159858910367, 0.9995985627174377, 0.0002133707021130249, 2.0723075067508034e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0446.jpg\tFebi. 1652. In't schip den Drommedaris.; Brimofeb.\t[0.00015376415103673935, 0.9996222257614136, 0.00020763477368745953, 1.6325227989000268e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0447.jpg\tIn't schip den Drommedaris; feb. 1652.; 19=e d=os \t[0.00016936272731982172, 0.999614953994751, 0.000199252855964005, 1.6463338397443295e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0448.jpg\tIn't schip den Drommedaris; feb„ 1652; drie op den\t[0.0001444661320419982, 0.9995880722999573, 0.00024828483583405614, 1.9170700397808105e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0449.jpg\tIn't Schip den drommedaris; brete 8. gr: 18 min: e\t[0.00014548968465533108, 0.999618649482727, 0.0002178569120587781, 1.796906508388929e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0450.jpg\tMartio 1652. Int schip den Drommedaris.; Heden ons\t[0.00015665018872823566, 0.9996284246444702, 0.00019739048730116338, 1.752987918735016e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0451.jpg\tIn't schip den Drommedarit; 201; 16=e do de wint h\t[0.00016166757268365473, 0.9996070265769958, 0.00021385634317994118, 1.757112841005437e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0452.jpg\talsoo van hem vernamen dat tot dato noch een heele\t[0.00017596363613847643, 0.999586284160614, 0.000218189787119627, 1.959084147529211e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0453.jpg\tstelden cours Oende Oost ten z tusschen beijden; d\t[0.00015005560999270529, 0.999610960483551, 0.0002201320749009028, 1.881466778286267e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0454.jpg\tin Godes name aente doen, ende van nu tot; morgen \t[0.00015984286437742412, 0.9996237754821777, 0.0001981817913474515, 1.8173292119172402e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0455.jpg\tApril 1652. In't schip den Drommedaris; 2=e d=o wi\t[0.00016117803170345724, 0.9995879530906677, 0.0002323860680917278, 1.8442015061737038e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0456.jpg\tApril 1652.; In't schip den Drommedaris.; seijmsn:\t[0.0001502198720118031, 0.9996243715286255, 0.0002083667932311073, 1.7027052308549173e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0457.jpg\tApril 1652. In't schip den Drommedaris.; off missc\t[0.00022899359464645386, 0.9994760155677795, 0.00027253711596131325, 2.2549120330950245e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0458.jpg\tIn't schip den Drommedaris ter Rheede; aen Cabo de\t[0.0001645173178985715, 0.9996178150177002, 0.0001991804747376591, 1.8416270904708654e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0459.jpg\tIn't schip den Drommedaris ter Rhede; aen Cabo de \t[0.00015446972975041717, 0.9995827078819275, 0.0002445788122713566, 1.824173887143843e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0460.jpg\tIn't schip den Drommedaris ter Rheede.; aende Cabo\t[0.000148483770317398, 0.999638557434082, 0.00019613935728557408, 1.682526090007741e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0461.jpg\tIn't schip den Drommedaris ter Rhede; aen Cabo de \t[0.0001878955081338063, 0.9995649456977844, 0.00022776266268920153, 1.938362038345076e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0462.jpg\tApril 1652. In't schip den Drommedaris ter Rhede; \t[0.00020249154476914555, 0.9995412826538086, 0.00023575988598167896, 2.049301292572636e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0463.jpg\taen Cabo de boâ Esperance,; Soo dated= becoomen ti\t[0.00017302886408288032, 0.9995939135551453, 0.00021395922522060573, 1.9047583919018507e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0464.jpg\tApril 1652. In't schip den Drommedaris ter Rhede.;\t[0.00015288787835743278, 0.9996234178543091, 0.00020661125017795712, 1.7049182133632712e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0465.jpg\tIn't schip den Drommedaris ter Rhede; aen Cabo de \t[0.00014908054436091334, 0.9996223449707031, 0.00021163051133044064, 1.6935873645707034e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0466.jpg\tApril 1652. Init schip den Drommedaris ter Rhede; \t[0.00018062794697470963, 0.9995794892311096, 0.0002224706840934232, 1.74513606907567e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0467.jpg\t3 April 1652. Int schip den Drommedaris ter Rhede;\t[0.0001459101913496852, 0.9996142387390137, 0.0002233800623798743, 1.6484740626765415e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0468.jpg\t2April 1652 In't schip den Drommdaris ter Rhede.; \t[0.00020158679399173707, 0.9995540976524353, 0.0002240206958958879, 2.0255296476534568e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0469.jpg\tApril 1652. In't schip den Drommedaris ter Rhede; \t[0.00016231393965426832, 0.9995869994163513, 0.000231963160331361, 1.8729486328084022e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0470.jpg\t2 April 1652. In 't schip den Drommedaris ter Shel\t[0.0001810408430173993, 0.9995777010917664, 0.0002239085006294772, 1.73716416611569e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0471.jpg\t3 April 1652 In't schip den Drommedaris ter Rhede.\t[0.00014704393106512725, 0.999613344669342, 0.00022354332031682134, 1.6133644749061204e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0472.jpg\tApril 1652. In't schip den Drammdaaris ter shede.;\t[0.00016469803813379258, 0.9995112419128418, 0.0003037478600163013, 2.019946805376094e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1188_0473.jpg\taen Cabo de boâ Esperance.; Savonts even nasons on\t[0.00022712517238687724, 0.9978172779083252, 0.0019204734126105905, 3.51089438481722e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1188_0474.jpg\tApril 1652. In't schip den Drommedaris ter Rhede; \t[3.2396175811300054e-05, 0.00016047268582042307, 0.9998045563697815, 2.5969677608372876e-06]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0236.jpg\t\t[0.00027818692615255713, 0.0005887658335268497, 0.00014860679220873863, 0.9989843964576721]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0237.jpg\taan d'E: Heer Alexander; Wigmans Coopman en P„r; g\t[0.9998546838760376, 6.320248212432489e-05, 4.518053538049571e-05, 3.696012936416082e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0238.jpg\teenige misnoegentheijt, in die natie ligt aan„; „w\t[0.0024784677661955357, 0.9962366223335266, 0.0008351995493285358, 0.00044971585157327354]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0239.jpg\teen vast voorneemen, 'tsij het leven aldaar te; ve\t[0.00047981241368688643, 0.9990280866622925, 0.0004280015709809959, 6.408875196939334e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0240.jpg\t„gemelte schrijvens tomtwaaren, ook hoe uEE:; goet\t[0.00019357632845640182, 0.9995428323745728, 0.0002352127485210076, 2.8355558242765255e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0241.jpg\tHeest in alle mijne brieven heb ik voor uEE:; mijn\t[0.00015807956515345722, 0.9995736479759216, 0.00024290758301503956, 2.5369574359501712e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0242.jpg\tzout en sandel, onder behoorlijk verbant schrift; \t[0.00017430787556804717, 0.9995781779289246, 0.00022279312543105334, 2.4664912416483276e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0243.jpg\tVE: bekent gemaakt, dat Eergister van; Calicoet al\t[0.00015089899534359574, 0.9996100068092346, 0.00021916828700341284, 1.986251118069049e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0244.jpg\tmijs goet gedagt heeft hier ter neder te; stellen,\t[0.00015168070967774838, 0.9995908141136169, 0.00023496508947573602, 2.247204065497499e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0245.jpg\ten't belangh der generaale Comp:e, omtr. t; den st\t[0.00015052557864692062, 0.9996137022972107, 0.00021423214639071375, 2.1523979739868082e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0246.jpg\twat belangt het aanslaan van 'tsandelhout; uijt uE\t[0.00016495355521328747, 0.9996053576469421, 0.00020718622545246035, 2.2514517695526592e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0247.jpg\tuE: E: agtb: hoog g'Extimeerde, en overaange„; „na\t[0.0001448383554816246, 0.9996036887168884, 0.0002287571842316538, 2.2736096070730127e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0248.jpg\tbetuijgen, Indien uw EE: agtb: ondersoght; en over\t[0.00017941388068720698, 0.999534010887146, 0.0002649787929840386, 2.1515203115995973e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0249.jpg\tCochim hadden mij gesz:, en mijn overkomst; aldaar\t[0.00015017495024949312, 0.9996028542518616, 0.00022511424322146922, 2.19117064261809e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0250.jpg\tverguningen, in't bijweesen van d'aff gesanten,; a\t[0.00014107557944953442, 0.9996063113212585, 0.00023072636395227164, 2.1894402379984967e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0251.jpg\tvoorsz:, en seer genereuse; Heer; manhafte, Welwij\t[0.00014988206385169178, 0.9995933175086975, 0.0002366692351642996, 2.0192746887914836e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0252.jpg\tdie mij In't portugees geschrift een vol; brogt, d\t[0.0001346996723441407, 0.9996028542518616, 0.0002459187526255846, 1.655113919696305e-05]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 35%|███▌      | 4/11.3125 [00:03<00:06,  1.06batch/s]"
+      " 42%|████▏     | 10/24 [00:01<00:01, 13.70batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1506_1034.jpg\t-; d; E; 7.; decken; 8; 2; van de; 5; ƒ; 3; E; E; \t[0.999672532081604, 0.0002436629729345441, 5.570215216721408e-05, 2.817159656842705e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1506_1035.jpg\tbinnewater; een lamme; D95; same; uijt; ies; Cas; \t[0.0013309026835486293, 0.9972808361053467, 0.0013826104113832116, 5.614747806248488e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1506_1036.jpg\t30 vrs; o; Janor; 6; 5o; e; x; 116; E; 6.; 1.; :; \t[0.0011187694035470486, 0.9959751963615417, 0.0029000823851674795, 5.9029798649135046e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1506_1037.jpg\tk; „noortvelt; rogons; „1; rsame; uijt; eruijt; ƒ;\t[0.00011362581426510587, 0.0002934639051090926, 0.9995860457420349, 6.863442195026437e-06]\n"
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0253.jpg\tvan d' Ed=le H„r Directeur; en Raad tot Zouratta z\t[0.0001891237625386566, 0.999565064907074, 0.00022197455109562725, 2.3785076336935163e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0254.jpg\ttwoorenstaande formelier, gisteren voor de; middag\t[0.00015430280473083258, 0.9995915293693542, 0.00023246802447829396, 2.1642721549142152e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0255.jpg\tNo/a, ook wel 140. maar tegens 135. gereek. t,; â \t[0.0001369184465147555, 0.9996145963668823, 0.0002278776082675904, 2.0600311472662725e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0256.jpg\tmeugt hoedanigh ick volgens mijn schuldige; pligt;\t[0.00015061532030813396, 0.9996059536933899, 0.00022092173458077013, 2.2558742784895003e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0257.jpg\tuE: twee aangenaame brieven gedat. t; 22. en en 25\t[0.00014808033301960677, 0.9995786547660828, 0.0002490175829734653, 2.4197321181418374e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0258.jpg\tvorsten mondelijk raatspleeginge gehouden; hebbend\t[0.00013681722339242697, 0.9995998740196228, 0.00024161733745131642, 2.1650765120284632e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0259.jpg\twoord, dat uE: alhier zijnde geen de minste; weder\t[0.0001569539454067126, 0.9995991587638855, 0.00021944448235444725, 2.440042226226069e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0260.jpg\tder Coopmansz: in Zouratta als het aff„; wijsen va\t[0.00015021147555671632, 0.9995923638343811, 0.00023514433996751904, 2.2239048121264204e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0261.jpg\tsier avont sond mij den ko: van Sammorijn; uw. E: \t[0.00021650946291629225, 0.9994970560073853, 0.00025943576474674046, 2.6900861485046335e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0262.jpg\tP: S: alles wat ik volgens mijn geringe ver„; „sta\t[0.00014714391727466136, 0.9996225833892822, 0.00020933999621775, 2.0880532247247174e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0263.jpg\tden Jnhoude derzelve, en ons gedaan versoek; verde\t[0.00015111546963453293, 0.9996024966239929, 0.00022458151215687394, 2.1860958440811373e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0264.jpg\tE: Agtb: Gebiedende Heer; mijn heeft niet omstandi\t[0.00014188843488227576, 0.9996066689491272, 0.00023083429550752044, 2.0573348592733964e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0265.jpg\tgebeurde dat op uw EE: agtb: begeerte sigh; op rij\t[0.00014583062147721648, 0.9996114373207092, 0.0002222377370344475, 2.050707917078398e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0266.jpg\tCochim; aan d' E: E: Heer adriaan; r; van ommen Co\t[0.0001598841045051813, 0.9995728135108948, 0.0002452688931953162, 2.2001631805323996e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0267.jpg\twaarop ick mij ook verlaaten, niet twijffelende; o\t[0.00014637038111686707, 0.9996046423912048, 0.00022593063476961106, 2.3097400116967037e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0268.jpg\tbetreft den Coningh van Sammorijn soo wel; als d' \t[0.00017420145741198212, 0.9995711445808411, 0.00023209888604469597, 2.2576292394660413e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0269.jpg\tverwerpt, soo kan hij ons in den handel aldaar; so\t[0.00014762242790311575, 0.9995868802070618, 0.00024176794977393, 2.3751277694827877e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0270.jpg\t'twelk doende een groote affschrick in de; herten \t[0.0001534726470708847, 0.99946528673172, 0.0003581502824090421, 2.3135533410822973e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0271.jpg\tden markt vermeestert, en konnen ook op dien; voer\t[0.00019791271188296378, 0.9976755976676941, 0.002093963325023651, 3.2625201129121706e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0272.jpg\tbehulpsaamh. t te bewijsen, op dat dien Corl in; g\t[3.198299600626342e-05, 0.00018760524108074605, 0.9997773766517639, 3.085959860982257e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0108.jpg\top desen holvn en dass: matthijs in ve totenende a\t[0.9999078512191772, 6.723916158080101e-05, 2.2401523892767727e-05, 2.4443186248390703e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0109.jpg\tVoegens en ein nwige tebeversigen stan de en heele\t[0.0009845743188634515, 0.9956860542297363, 0.0032338800374418497, 9.552541450830176e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0110.jpg\tgemerkt &E.; Waarmeede; Edele hoog agtbaare gebied\t[3.412052683415823e-05, 0.00013813861005473882, 0.9998254179954529, 2.3535508262284566e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0107.jpg\tExtracten uijt de Daagelijkse Aanteeckeningen, Con\t[0.9999264478683472, 3.677891436382197e-05, 3.41428276442457e-05, 2.685658728296403e-06]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0108.jpg\top desen holvn en dass: matthijs in ve totenende a\t[6.618881889153272e-05, 9.215174213750288e-05, 0.9998382329940796, 3.4331415008637123e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1490_0583.jpg\tCopije Secrete Resolutien; genomen bij de Ho: Rege\t[0.9998964071273804, 8.327567047672346e-05, 1.8155256839236245e-05, 2.1962321170576615e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0584.jpg\tin presentie; van zijn Ed. t te; volbrengen, soo s\t[0.0009327990701422095, 0.9985276460647583, 0.0004648854664992541, 7.458525215042755e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0585.jpg\tdat 's Comp. s dienaren en wel voorna„; mentlijk p\t[0.00029814723529852927, 0.9993829727172852, 0.0002894828503485769, 2.9453252864186652e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0586.jpg\tbij ons te boeck staen voor niet wel; geintentione\t[0.00020511703041847795, 0.9995520710945129, 0.0002212338731624186, 2.1520969312405214e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0587.jpg\tgoetgevonden dat dese ontbiedinge; bij ons gemeen \t[0.00019058215548284352, 0.9995706677436829, 0.00021933508105576038, 1.944709219969809e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0588.jpg\tschaap harder herwaerts aen te doen; overkomen, ge\t[0.00016912451246753335, 0.9995978474617004, 0.0002129672357114032, 2.0049288650625385e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0589.jpg\tmilitie daer in te houden in goede; ordre soo is v\t[0.00016027310630306602, 0.9996232986450195, 0.0001979115913854912, 1.8489863577997312e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0590.jpg\tdertig of veertigh persoonen ten; hoogsten; genome\t[0.00016150603187270463, 0.9996106028556824, 0.0002075468364637345, 2.0351202692836523e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0591.jpg\twillem van outhoorn, wouter; valkenier, abraham va\t[0.0001724033645587042, 0.9996050000190735, 0.0002046171430265531, 1.8028826161753386e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0592.jpg\tsijner goet staende maentgelden; en verdere annexe\t[0.00015891017392277718, 0.9995977282524109, 0.00022392217942979187, 1.942415110534057e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0593.jpg\tmaer sijne valsche betigters; en aenklagers tumput\t[0.0001529269793536514, 0.9996263980865479, 0.00020294476416893303, 1.7699829186312854e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0594.jpg\taen uwe Edelhedens, niet; demoedig versoeck, dat u\t[0.0001540794619359076, 0.9996145963668823, 0.00021330415620468557, 1.796768992790021e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0595.jpg\tacte van herstellinge en verdere; ten desen dienen\t[0.00015402224380522966, 0.9996132254600525, 0.00021500245202332735, 1.78055797732668e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0596.jpg\ten omme de france vijanden, soo der; eenige quamen\t[0.000161448260769248, 0.999593198299408, 0.00022571570298168808, 1.969622098840773e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0597.jpg\tde ridderschap voerende 60. stucken ges:t; waterla\t[0.0001937797205755487, 0.9995554089546204, 0.00023011605662759393, 2.071392191282939e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0598.jpg\tstierlijk pennisten, kranckbesoekers; en chirurgij\t[0.00016208665329031646, 0.9996065497398376, 0.00021337118232622743, 1.8003838704316877e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0599.jpg\tvan hier nevens „200.; en uijt 170. Comp:s lijfeij\t[0.0001621721894480288, 0.9996039271354675, 0.00021502403251361102, 1.8926742995972745e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0600.jpg\tsterck 1662. Coppen, daer onder; gerekent, de oude\t[0.00018126289069186896, 0.9995588660240173, 0.00024001020938158035, 1.991519093280658e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0601.jpg\tbleven met 70. â 80. jnlanders, als; mede ongevaer\t[0.00016581473755650222, 0.9995986819267273, 0.00021797952649649233, 1.749837610987015e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0602.jpg\tsodanig quame te vereijsschen, ende; sonder dat ie\t[0.00017361213394906372, 0.9995593428611755, 0.000246979296207428, 2.002083056140691e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0603.jpg\tveranderinge ofte bijvoeginge diende; te geschiede\t[0.00014726231165695935, 0.9996324777603149, 0.00020067401055712253, 1.9533446902642027e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0604.jpg\tdiscoureren en te verklaren hoe; dat hij bij sig s\t[0.00014719912724103779, 0.9996353387832642, 0.00019860184693243355, 1.8790417016134597e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0605.jpg\tquamen overvallen en aentasten:; soo meende sijn E\t[0.00015859771519899368, 0.9996150732040405, 0.0002092719660140574, 1.7047999790520407e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0606.jpg\tdeselve niet ten proije mogten werden,; wanneer on\t[0.00014502192789223045, 0.999631404876709, 0.0002057846140814945, 1.7741509509505704e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0607.jpg\tvan meerdere versekeringe mogten; oordelen behoord\t[0.0001523261598777026, 0.9996390342712402, 0.00019102610531263053, 1.7660631783655845e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0608.jpg\tvanden Command:r Sijmon vander; stel, en raed aend\t[0.00017588086484465748, 0.9995926022529602, 0.00021343558910302818, 1.8167040252592415e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0609.jpg\talthans te deser rhede leggende; zeemagt wel van e\t[0.00016215111827477813, 0.9996094107627869, 0.00020865497936028987, 1.9798104403889738e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0610.jpg\tvan het verleden Iaer, als wanneer; volgens het sp\t[0.00015598464233335108, 0.9996108412742615, 0.00021586811635643244, 1.7307493180851452e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0611.jpg\twas, onaengesien het goet succes; der negotie veel\t[0.00015978107694536448, 0.9995939135551453, 0.00022802790044806898, 1.8292394088348374e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0612.jpg\twas getekent; als vooren.; willem van Outhoorn,; w\t[0.00013908969413023442, 0.999616265296936, 0.00022647151490673423, 1.8060316506307572e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0613.jpg\tdat over de saken van Japan aen; dese tafel wierde\t[0.0001738450228003785, 0.9995751976966858, 0.0002326429821550846, 1.8369773897575215e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0614.jpg\ttot uijtvindinge van een expedient,; waer door de \t[0.00021037491387687624, 0.9995511174201965, 0.00021590196411125362, 2.2689655452268198e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0615.jpg\ten ons buijten postuer te brengen,; om de dierbare\t[0.00015001285646576434, 0.9996262788772583, 0.00020535597286652774, 1.8300839656149037e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0616.jpg\ta:o 1684. wierde geordonneert in; haere herwaerts \t[0.0001591952604940161, 0.99960857629776, 0.00021339685190469027, 1.8789913156069815e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0617.jpg\trijkelijk te konnen versorgen,; mitsgaders het mis\t[0.0001593028282513842, 0.999605119228363, 0.00021526783530134708, 2.0388699340401217e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0618.jpg\tgepractiseert geworden is, sullen; moeten doen hou\t[0.0002049229951808229, 0.9995498061180115, 0.00022317830007523298, 2.1992545953253284e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0619.jpg\tover te steeken, agtervolgens; sodanige Zeijlaes o\t[0.00015367224114015698, 0.9996155500411987, 0.000211832404602319, 1.890463136078324e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0620.jpg\tgecarteert legt, maer dat oock de; stronien inde m\t[0.00016483530635014176, 0.9995977282524109, 0.0002191996609326452, 1.8288907085661776e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0621.jpg\tde stranen sig veeltijts daer na; reguleeren van g\t[0.00015538849402219057, 0.9996126294136047, 0.00021459242270793766, 1.7449059669161215e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0622.jpg\teen weg is, nu wel eenige jaren; van japan na bata\t[0.00013632941409014165, 0.999618649482727, 0.0002269793039886281, 1.7986825696425512e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0623.jpg\tten zuijden om beoosten de eijlanden; van natuna o\t[0.00014895205094944686, 0.999605119228363, 0.00022853771224617958, 1.74095002876129e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0624.jpg\tnog een droogte genaemt kleijn; enckhuijser sant, \t[0.00015078902652021497, 0.9996256828308105, 0.00020701898029074073, 1.6497242540935986e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0625.jpg\tlange jaren niet voorgevallen is; dat dese coursen\t[0.00016999599756672978, 0.9995762705802917, 0.00023555869120173156, 1.8172653653891757e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0626.jpg\tvan siam en Toncquin herwaerts; sullen komen, als \t[0.0001564295671414584, 0.9996029734611511, 0.00022033655841369182, 2.0304907593526877e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0627.jpg\tvan een hogre prijse als ordinair; te nootsaeken, \t[0.00015705735131632537, 0.9996111989021301, 0.00021259972709231079, 1.9181843526894227e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0628.jpg\tals voren. was getekent. . ..; . . . . - Willem va\t[0.00013971884618513286, 0.9996223449707031, 0.00022042302589397877, 1.7559255866217427e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0629.jpg\tin eenig emploij van onsien kan; werden gebruijckt\t[0.00016308692283928394, 0.9995429515838623, 0.0002751972933765501, 1.878823240986094e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1490_0630.jpg\tvoorde schipper aende Tafel en in het; gebet, eeni\t[0.0002545148890931159, 0.998187243938446, 0.0015273026656359434, 3.0913783120922744e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1490_0631.jpg\tBo0; Secrets.; wee; De bovenstaende secrete resolu\t[3.5801964259007946e-05, 0.00019382323080208153, 0.9997673630714417, 3.0823698580206838e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_2615_0147.jpg\tLijste van alle sodanige 's E: Comp:s; dienaren al\t[0.9998854398727417, 8.87194401002489e-05, 2.282035165990237e-05, 3.053264890695573e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2615_0148.jpg\tmet wat schip in Jndia gekomen; geboorte pl=s indi\t[0.000645402236841619, 0.9987977743148804, 0.0004935241886414587, 6.32365481578745e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2615_0149.jpg\tmet wat schip in Jndien gekomen; geboorte plaets w\t[0.000323093612678349, 0.997793436050415, 0.001841496443375945, 4.201749470666982e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_2615_0150.jpg\tmet wat schipis Jndia gekomen; geboorte p=s wannee\t[3.057429057662375e-05, 0.0001392088452121243, 0.9998278617858887, 2.219918087575934e-06]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0456.jpg\t\t[9.621472418075427e-05, 0.00026893705944530666, 4.7768618969712406e-05, 0.9995871186256409]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0457.jpg\t\t[2.40142489928985e-05, 6.064776607672684e-05, 1.0088218914461322e-05, 0.9999052286148071]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0458.jpg\t\t[2.956944445031695e-05, 6.144063081592321e-05, 1.7602380466996692e-05, 0.9998914003372192]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0459.jpg\tRapport gedaen Ter ordre; van d' E. heer Adriaen V\t[0.9995577931404114, 7.019043550826609e-05, 5.3684467275161296e-05, 0.000318299513310194]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0460.jpg\tdat den bovengem: veltheer, zyn seconde genaem; pi\t[0.02223372831940651, 0.9492400288581848, 0.0027624957729130983, 0.025763802230358124]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0461.jpg\t212; lieten uijtwaijen sonder te konnen uijtten op\t[0.0037610300350934267, 0.9932147264480591, 0.0008692714036442339, 0.002155041554942727]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0462.jpg\tden principaelsten schelm naer mijn gesegt wert ov\t[0.0004774352419190109, 0.999038577079773, 0.0003194386954419315, 0.00016463473730254918]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0463.jpg\tden schadt van d' E Comp:e niet kwam aen tewijsen;\t[0.00022304701269604266, 0.9994783997535706, 0.0002522599243093282, 4.635954974219203e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0464.jpg\tWingurla dus verre verrigt waeren heefen sigh zijn\t[0.00014455568452831358, 0.9995793700218201, 0.00024468248011544347, 3.131559424218722e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0465.jpg\tvoor ons thien menschen intgetal wierd opgedist; e\t[0.00015093052934389561, 0.9994640946388245, 0.0003570227709133178, 2.805315853038337e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0466.jpg\tom welke voorseijde reedenen hy velt overste den r\t[0.0001757422141963616, 0.9978506565093994, 0.001936515443958342, 3.713733167387545e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0467.jpg\tWaer seven daegen zoo aen mijn lighaem te verschoo\t[2.7695397875504568e-05, 0.00015807512681931257, 0.9998106360435486, 3.698580940181273e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 44%|████▍     | 5/11.3125 [00:04<00:07,  1.26s/batch]"
+      " 62%|██████▎   | 15/24 [00:01<00:00, 17.50batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3060_0043.jpg\tNa dat de Leeden deeser Vergaadering bij een geroe\t[0.9717885255813599, 0.010821838863193989, 0.001531894551590085, 0.015857649967074394]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0044.jpg\t\t[0.004722322802990675, 0.9493709206581116, 0.0015321957180276513, 0.04437460005283356]\n",
-      "OUT\tIN\tNL-HaNA_1.04.02_3060_0045.jpg\t\t[0.007382892072200775, 0.4826573133468628, 0.0038950678426772356, 0.5060647130012512]\n",
-      "OUT\tIN\tNL-HaNA_1.04.02_3060_0046.jpg\t\t[0.00460227532312274, 0.07550110667943954, 0.002633779775351286, 0.917262852191925]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_3060_0047.jpg\tWoensdag den 13: ' October A„o 1762.; Na dat de Le\t[0.9990507960319519, 0.000773828593082726, 6.256939377635717e-05, 0.00011286102380836383]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0048.jpg\tNagesien; G„s V„n Aken\t[0.0006021875306032598, 0.998832643032074, 0.0005534070078283548, 1.1793497833423316e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0049.jpg\tWoensdag den 13.:' October A„o 1762.; Na dat de Le\t[0.0004429000255186111, 0.9989116191864014, 0.0006400637212209404, 5.48712705494836e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0050.jpg\t\t[0.00018856636597774923, 0.9996403455734253, 0.00016884997603483498, 2.226365950264153e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0051.jpg\tDingsdag Den 2:' November A„o 1762. —; Den Raad bi\t[0.0003259384538978338, 0.9992011189460754, 0.0004702103906311095, 2.7024852897739038e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0052.jpg\tOver te haalen geweest, dan ruijm, een halff Capit\t[0.0003086228098254651, 0.9992207288742065, 0.000468130805529654, 2.5027261472132523e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0053.jpg\tDen bottelier Jan Fredrik Smit, van SHage; Hoffmee\t[0.0003080040623899549, 0.9992508292198181, 0.00043879984878003597, 2.3482602955482434e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0054.jpg\tNagesien; P: D Lahaije\t[0.00034751128987409174, 0.9985083937644958, 0.001141131273470819, 2.927337618530146e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0055.jpg\t\t[7.474747690139338e-05, 0.9997588992118835, 0.00016449566464871168, 1.8904104308603564e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0056.jpg\tNagesien; G: B: D Leeuw; d\t[0.0002799463109113276, 0.9991633892059326, 0.0005544282612390816, 2.249772705908981e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0057.jpg\tMaandag Den 15„e November A„o 1762. —; Het ingedie\t[0.00021810679754707962, 0.9988507032394409, 0.0009280692902393639, 3.1204417609842494e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0058.jpg\t\t[5.8035740948980674e-05, 0.999651312828064, 0.00028814852703362703, 2.5526228455419187e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0059.jpg\tAan den wel Edelen Agtb: Heere; Fredrik Willem Win\t[0.00016706687165424228, 0.999198853969574, 0.000631461851298809, 2.6729103410616517e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0060.jpg\t\t[7.107856799848378e-05, 0.9995469450950623, 0.0003768093592952937, 5.119145498611033e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0061.jpg\t\t[4.72973842988722e-05, 0.9997743964195251, 0.00017536479572299868, 2.9717202778556384e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0062.jpg\tNagesien; J:B: D Leeuw.\t[0.00025144353276118636, 0.999152421951294, 0.0005938347894698381, 2.2149658889247803e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0063.jpg\t\t[4.685004387283698e-05, 0.999716579914093, 0.00023126271844375879, 5.296661129250424e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0064.jpg\t\t[8.079639519564807e-05, 0.9997493624687195, 0.0001671453646849841, 2.706362010940211e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3060_0065.jpg\tE:E: Agtbaaren Heer Johannes Heijnouts; Sondergete\t[0.0006782092386856675, 0.9972317814826965, 0.002083816332742572, 6.235086857486749e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_3060_0066.jpg\tNoering hem daar toe sijne hulpe leenen; Voor 't o\t[0.00011268273374298587, 0.00047187641030177474, 0.9994056224822998, 9.839123777055647e-06]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1631_0289.jpg\tTwee Copie translaat briefien; door de hofs-groten\t[0.9999105930328369, 6.585857045138255e-05, 2.121354191331193e-05, 2.356615141252405e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0290.jpg\twederseijdse gesonth:t &:a bestaande :/ gevoerd; z\t[0.001078862464055419, 0.9983059167861938, 0.0005363075761124492, 7.894612645031884e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0291.jpg\tLuijden sig onthielden, en ondervondt; dat die dri\t[0.00024444443988613784, 0.9994757771492004, 0.00025385277695022523, 2.5926610760507174e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0292.jpg\tdaarom niet en konden gaan, derhalve; gelieve uEd:\t[0.00022657186491414905, 0.999492883682251, 0.0002580515865702182, 2.2533637093147263e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0293.jpg\tals 't haar maar In de zin quam; baldadigh, en sto\t[0.00019673268252518028, 0.9995738863945007, 0.00021093316900078207, 1.8427284885547124e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0294.jpg\thebben verstaan, en begrepen: waar—; na nogh eenig\t[0.0001670555939199403, 0.9996116757392883, 0.00020330166444182396, 1.797827826521825e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0295.jpg\tgedaan opsoeken, om sijn Ed:s met; dit geschenk /:\t[0.00015833806537557393, 0.9996167421340942, 0.0002063068386632949, 1.8616676243254915e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0296.jpg\tverwondert te wesen dat hij moddeljaar; soo langh \t[0.00015555450227111578, 0.9996179342269897, 0.00020886323181912303, 1.7592132280697115e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0297.jpg\taan haar believen stelden, om dat sij; mogelijk do\t[0.00014722032938152552, 0.9996134638786316, 0.00021890019706916064, 2.0438688807189465e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0298.jpg\tgerrit de heere / van dat hij in 't; opregt en met\t[0.0001713193632895127, 0.9994726777076721, 0.0003351805207785219, 2.0806681277463213e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1631_0299.jpg\tgetrouw en opregtelijck, en met soo; goede genegen\t[0.00020380059140734375, 0.9979210495948792, 0.0018464690074324608, 2.872422555810772e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1631_0300.jpg\top te houden oversulcx deselve, soo sij; genegen w\t[3.359465335961431e-05, 0.00017316440062131733, 0.999790370464325, 2.911130195570877e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1637_0144.jpg\tVan Banda de dato 25=en maij Ao 1700; Van banda on\t[0.9999077320098877, 6.727944128215313e-05, 2.256266998301726e-05, 2.4967632725747535e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1637_0145.jpg\tVan banda onder dato 25„e maij 1700; van banda ond\t[0.0009034108370542526, 0.9961081147193909, 0.0028975734021514654, 9.079167648451403e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1637_0146.jpg\tVan banda onder dato 25 maij 1700; Van banda onder\t[3.4747441532090306e-05, 0.00013079984637442976, 0.999832034111023, 2.306636133653228e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3174_0189.jpg\tDagregister, de anno 1766:—; Vrijdag den 21:' Maer\t[0.999906063079834, 7.056220783852041e-05, 2.067795503535308e-05, 2.7621899789664894e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3174_0190.jpg\tgelevert hebben, en belooven voortaen, meer; genoe\t[0.0006048143841326237, 0.9988213181495667, 0.0005107218748889863, 6.308707816060632e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3174_0191.jpg\tmaer den dienst vreedig kunnen doen; De Chialiasse\t[0.00035260795266367495, 0.9975888729095459, 0.0020129370968788862, 4.5538326958194375e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_3174_0192.jpg\tnaar gewoonte hun afscheit neemende; gingen weder \t[3.135546648991294e-05, 0.0001436724269296974, 0.9998227953910828, 2.2350782273861114e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3577_0649.jpg\tDag Register van het voor„; „gevallene op de Hongi\t[0.9999116659164429, 6.911456875968724e-05, 1.7248512449441478e-05, 1.9427277493377915e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0650.jpg\tOppeschidurgijn Hendrik Wendsel, en Luijtenant Mil\t[0.0011782264336943626, 0.998114824295044, 0.0006199831259436905, 8.693016570759937e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0651.jpg\tde Chineese met hunne vlaggetjes en speettuijg; zi\t[0.00026714775594882667, 0.9994701743125916, 0.00023702176986262202, 2.5579705834388733e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0652.jpg\tsandaart gesalueert wierd met Neegen Basschooten; \t[0.00020625715842470527, 0.999489426612854, 0.00028036904404871166, 2.3986871383385733e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0653.jpg\tverrigting van het nodige tot de verpligte recepti\t[0.00016065605450421572, 0.9995923638343811, 0.00022865054779686034, 1.8356693544774316e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0654.jpg\tBoompjes te tellen, van de plaats inspectie te nee\t[0.00016199771198444068, 0.9995976090431213, 0.00021947281493339688, 2.099185985571239e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0655.jpg\tHeer Gouverneur me perzoon nauwkeurige, zoo wel; h\t[0.00016067222168203443, 0.9995985627174377, 0.00022323898156173527, 1.752181924530305e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0656.jpg\tAdmiraal; Donoa of; Nissanive; _=o; fo; Groot Hati\t[0.0001570371532579884, 0.9996046423912048, 0.00021932162053417414, 1.9106386389466934e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0657.jpg\tgij Oioor van het Jaar 17eg; dan welEd: ben den da\t[0.00015587029338348657, 0.9996119141578674, 0.0002143036836059764, 1.8024295059149154e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0658.jpg\tTonoraaae Sima der Artnuuerg en; De Corre Corre Bo\t[0.00015899023856036365, 0.9996035695075989, 0.0002194996632169932, 1.799652454792522e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0659.jpg\tAmmunitie Goederen, waar meede de Ondervolgende Co\t[0.00015888466441538185, 0.9995926022529602, 0.000229331519221887, 1.9243489077780396e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0660.jpg\tVervolg van den 23:' October, des Avonds om tien u\t[0.00016352934471797198, 0.9996035695075989, 0.00021289898722898215, 2.006185422942508e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0661.jpg\tg'excorteert van deszelfs Lijfragt met de Hongij v\t[0.0001455428428016603, 0.9996262788772583, 0.00020980526460334659, 1.8346428987570107e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0662.jpg\thet welke de vloot des voordemiddags ten Elf uuren\t[0.00016476259042974561, 0.9995893836021423, 0.0002281702181790024, 1.767416142683942e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0663.jpg\tzoo momentlijk van Manipa bedeelt werd de ver„; „s\t[0.0001448796538170427, 0.9996273517608643, 0.00020972747006453574, 1.7996368114836514e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0664.jpg\ten kelang de Admiraals vlag begroeven zag met Twee\t[0.0001597417431185022, 0.9995927214622498, 0.00022833466937299818, 1.9195524146198295e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0665.jpg\tspil speelden, waarmeede z den wel Edele Agtb: Hee\t[0.00014978153922129422, 0.9996252059936523, 0.0002085626038024202, 1.641150811337866e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0666.jpg\tAgtb: Hier opgesagt hadden, ten eijnde zig op een \t[0.0001525969710201025, 0.9996175765991211, 0.00021206973178777844, 1.7714264686219394e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0667.jpg\thet geboomte niets naamwaardigs naar het beschreev\t[0.00019407137006055564, 0.9995552897453308, 0.00023246114142239094, 1.811558468034491e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0668.jpg\top de Landstreeks kapalle, koupele, Soupessij en M\t[0.00015829227049835026, 0.999618411064148, 0.00020581530407071114, 1.7436368580092676e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0669.jpg\tbuijten met zalen onderschraagt wierde, welke alle\t[0.00014707629452459514, 0.9996225833892822, 0.00021231808932498097, 1.7962556739803404e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0670.jpg\ttot onder het gaet van keffing alle moogelijke hul\t[0.00015293479373212904, 0.9996174573898315, 0.00021253192971926183, 1.6996013073367067e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0671.jpg\tSaturdag den 30: Dito der voordemiddags had den we\t[0.0001724799076328054, 0.9996044039726257, 0.00020304365898482502, 2.0149516785750166e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0672.jpg\twelke daar van reeds waijde opgehaald zijnd, wierd\t[0.00016735262761358172, 0.9995972514152527, 0.00021746366110164672, 1.7990627384278923e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0673.jpg\tgewoon salut van de Admiraals Orembaij na Land; en\t[0.00017444242257624865, 0.9995924830436707, 0.00021324126282706857, 1.9909022739739157e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0674.jpg\ten foelij hunne kleine Orembaijen diese agtersaage\t[0.00016670215700287372, 0.9996042847633362, 0.0002099933917634189, 1.903704833239317e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0675.jpg\tOstrouwskij g'ordonneert de eerste om het alhier B\t[0.00016435376892331988, 0.9996055960655212, 0.00021245908283162862, 1.7681679310044274e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0676.jpg\tMartens inhoudende dat bij het oversteeken der Cor\t[0.000164433557074517, 0.9996064305305481, 0.00021010261843912303, 1.9037306628888473e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0677.jpg\trespect /: onderstond:/ Wel Edele Gestrenge en Agt\t[0.00015805140719749033, 0.9996110796928406, 0.00021255832689348608, 1.8327422367292456e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0678.jpg\tvertrek bepaald op deesen agtermiddag alles in ger\t[0.0001701306173345074, 0.9996001124382019, 0.00021086004562675953, 1.8913624444394372e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0679.jpg\t„b'antwoord wierd, komende daar na gemelde Residen\t[0.00015427735343109816, 0.9996086955070496, 0.00021858290710952133, 1.8490332877263427e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0680.jpg\tvlag weeder overgebragt waar; Terstond wierd op he\t[0.00014778770855627954, 0.9995899796485901, 0.0002421669923933223, 2.002929431910161e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0681.jpg\ten Leesenaar met de Banken te vernieuwen, en zulx \t[0.00014666753122583032, 0.9996156692504883, 0.00021968199871480465, 1.7954878785531037e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0682.jpg\ten dat higt en sterk bevindende retiteerde na het \t[0.00015080487355589867, 0.9996421337127686, 0.0001888697879621759, 1.824645914894063e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0683.jpg\tfleurige Capas Boom van de beste, zoort en rijk va\t[0.00016292468353640288, 0.9996175765991211, 0.00020059201051481068, 1.8848215404432267e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0684.jpg\tom van desselfs verrigting weegens de onder zijn o\t[0.0001598777307663113, 0.9996311664581299, 0.0001904821110656485, 1.842382516770158e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0685.jpg\tDeesen gantschen dag met het bij den ander brangen\t[0.0001462800137232989, 0.9996201992034912, 0.0002154327230527997, 1.8094697225023992e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0686.jpg\tvan ieder Corra Corna hun gekapte balken aan vlott\t[0.00015814656217116863, 0.9995958209037781, 0.0002275742735946551, 1.8517164789955132e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0687.jpg\tDes Agtermiddags omstreeks vijf uuren, wierd de Ad\t[0.00014754205767530948, 0.9996335506439209, 0.00020173842494841665, 1.719742067507468e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0688.jpg\tvoormeld Hoofd Galloo desselfs afschud kreeg en ve\t[0.00013952041626907885, 0.9996144771575928, 0.00022879087191540748, 1.7181355360662565e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0689.jpg\tmet zeegeninge verzelt sal weesen, hebben wij dier\t[0.0001717363193165511, 0.9996059536933899, 0.00020479578233789653, 1.7492997358203866e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0690.jpg\t„lingen succesief aangebragt wierden opstrand te h\t[0.00015069883374962956, 0.9996253252029419, 0.00020691490499302745, 1.7079892131732777e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0691.jpg\tGisteren Avond, zijn mij gewerden: uwEd: Letteren \t[0.00017375033348798752, 0.9995701909065247, 0.0002385572443017736, 1.749874536471907e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0692.jpg\t/.was geteekend./. B„s van Sleuren. /: in margine \t[0.00015152791456785053, 0.9996215105056763, 0.00020738963212352246, 1.9590335796237923e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0693.jpg\tna gedaan seijn anker geligt wierd, en de vloot on\t[0.00017437570204492658, 0.9995942711830139, 0.00021230438142083585, 1.9086612155660987e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0694.jpg\tals van buijten, mitsg:s d' ahier zijn de Aituller\t[0.00016309252532664686, 0.9996210336685181, 0.000197354587726295, 1.8444330635247752e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0695.jpg\tden overbreng van 's Comp=s sagoe, welke ordres wa\t[0.00014932193153072149, 0.9995664954185486, 0.0002658396842889488, 1.838724892877508e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0696.jpg\tbesigtigde 414: p=s Jatij Bomen van 30: tot 40: vo\t[0.00013854190183337778, 0.9996460676193237, 0.0001980733941309154, 1.7303946151514538e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0697.jpg\tquam Circa half Negen uuren voor de Negorij Pieroe\t[0.00014587015903089195, 0.9996059536933899, 0.00022952099971007556, 1.8665148672880605e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0698.jpg\tschool te ontstaan ten zij in 't leesen en schrijv\t[0.00018096946587320417, 0.9995610117912292, 0.00023725637583993375, 2.073698487947695e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0699.jpg\tOm drie uuren vertrak den wel Edele Agtb: Heer Gou\t[0.00014654443657491356, 0.9996466636657715, 0.00018967839423567057, 1.7104983271565288e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0700.jpg\tnaar 't nuttige van een fris glas wijn vertrocken \t[0.00017117225797846913, 0.9995834231376648, 0.0002259642060380429, 1.945307303685695e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0701.jpg\tbesigtigt, en wel bevonden, terwijl de daar instaa\t[0.0001481308281654492, 0.9996259212493896, 0.00020623006275855005, 1.9669310859171674e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0702.jpg\tIn alle eerbied hebben wij de eere te rescribeeren\t[0.0001491053990321234, 0.9996201992034912, 0.00021396832016762346, 1.6689991753082722e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0703.jpg\tOm vier uiren begaf welm: zijn wel Edele Agtb: zig\t[0.00015809077012818307, 0.9995883107185364, 0.00023444140970241278, 1.924001298903022e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0704.jpg\tzijn wel Edele Agtb: met het gezelschap om 7: urre\t[0.00018045745673589408, 0.9995983242988586, 0.000200004389625974, 2.123279955412727e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0705.jpg\tRegent met oogmerk om bij zijn wel Edele Agtb: een\t[0.00015345837164204568, 0.9996238946914673, 0.00020369348931126297, 1.8999586245627142e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0706.jpg\ten de meenigte omstanders vriendelijk gegroet hebb\t[0.00015762762632220984, 0.9996041655540466, 0.0002203338808612898, 1.784991218301002e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0707.jpg\tEdele Agtb: een gespreck met den Alphoer Orangkaij\t[0.00017375937022734433, 0.9995563626289368, 0.0002506727469153702, 1.9180883100489154e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0708.jpg\tverscheide plagten teegens elkander in waar uijt g\t[0.0001621606497792527, 0.9995872378349304, 0.0002319123304914683, 1.8715169062488712e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0709.jpg\tvoor zijn wel Edele Agtb: betuijgen dat z voor dE \t[0.00016753346426412463, 0.999580442905426, 0.00023224673350341618, 1.9725104721146636e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0710.jpg\tbenoemd na de Gebergtens van waijsamoe, terwijl om\t[0.00016179769590962678, 0.9994997978210449, 0.0003187132824677974, 1.96600394701818e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0711.jpg\tvoorzeijde Orangkaij basse nog een Glaasje, vertro\t[0.0002558344276621938, 0.9962570667266846, 0.0034464458003640175, 4.0658749639987946e-05]\n",
+      "END\tIN\tNL-HaNA_1.04.02_3577_0712.jpg\tte verrigten, gelijk de vloot dan ook om seeven uu\t[3.599310730351135e-05, 0.00018354042549617589, 0.9997773766517639, 3.1338631742983125e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 53%|█████▎    | 6/11.3125 [00:06<00:07,  1.35s/batch]"
+      " 75%|███████▌  | 18/24 [00:01<00:00, 17.28batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1088_0511.jpg\tNaer dat den 8en. septembr 1625, het fergatt Surat\t[0.9995299577713013, 0.00038027067785151303, 5.3568310249829665e-05, 3.61987404176034e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0512.jpg\tdie van Lohoe waren hem gevolcht, tot op lebeleeuw\t[0.000736082496587187, 0.998572587966919, 0.0006874403916299343, 3.958030447392957e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0513.jpg\twederom afgesonden, naar Bouro, om te vernemen, wa\t[0.00042865300201810896, 0.9989858269691467, 0.000582914159167558, 2.585274387456593e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0514.jpg\tende ten deele onwillich, soo dat met schoon spree\t[0.00039627691148780286, 0.99903404712677, 0.0005673717241734266, 2.425034153930028e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0515.jpg\tons voor antwoort, dat wel waar was, dat sijn Vade\t[0.0003879569412674755, 0.9990419745445251, 0.0005676839500665665, 2.3906254682515282e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0516.jpg\tnoch al wel toeginck, ende mijn hier van noch vrij\t[0.00037304774741642177, 0.9990683197975159, 0.0005563857848756015, 2.2562601316167274e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0517.jpg\tblijcken wat parthij hij hielt van dese uijr affso\t[0.0003848453634418547, 0.999031662940979, 0.0005811068695038557, 2.431185521345469e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0518.jpg\tdus lange was gedaen, hebben den raet dit in Beden\t[0.0003658614296000451, 0.999068558216095, 0.0005631050444208086, 2.4951484647317557e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0519.jpg\tte mogen werden, met cruijt ende Loot, ende soo he\t[0.000388613116228953, 0.9990730285644531, 0.0005354683962650597, 2.913227945100516e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0520.jpg\tDen 9=en d=o smorgens, quamen voor Oerien, ofte no\t[0.00033083491143770516, 0.9990574717521667, 0.0006093983538448811, 2.32057254834217e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0521.jpg\tmede die van Cabau, den Sergeant aldaer op Hatuha \t[0.00025400155573152006, 0.9991673231124878, 0.0005759106134064496, 2.6939485451293876e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0522.jpg\tSijn voorts doorgepangaijt naer Oma, de corcoiren \t[0.00024546129861846566, 0.9987925291061401, 0.0009588291868567467, 3.1289973776438273e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0523.jpg\t\t[8.456283831037581e-05, 0.9994126558303833, 0.0004990313900634646, 3.7855336358916247e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0524.jpg\t\t[4.827751763514243e-05, 0.9996603727340698, 0.0002867144939955324, 4.662781975639518e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0525.jpg\t\t[3.0766390409553424e-05, 0.9998379945755005, 0.00012662635708693415, 4.588804131344659e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0526.jpg\t\t[5.8023830206366256e-05, 0.9998161196708679, 0.0001114564947783947, 1.4409305549634155e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0527.jpg\t\t[4.426787199918181e-05, 0.999848484992981, 9.675458568381146e-05, 1.049168440658832e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0528.jpg\t\t[4.8987825721269473e-05, 0.9998522996902466, 8.598091517342255e-05, 1.2806456652469933e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0529.jpg\t\t[6.0005735576851293e-05, 0.9998226761817932, 0.00010063667286885902, 1.6681164197507314e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0530.jpg\t\t[5.474875069921836e-05, 0.9998317956924438, 9.496723941992968e-05, 1.841938865254633e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0531.jpg\t\t[9.093455446418375e-05, 0.9997462630271912, 0.0001457376783946529, 1.703287853160873e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0532.jpg\tin Ambonia tsedert 8 septemb.; Daghregister vant g\t[0.0004185232683084905, 0.9988825917243958, 0.0006958474987186491, 3.050959094252903e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0533.jpg\t\t[0.0001893408189062029, 0.9996381998062134, 0.00016916441381908953, 3.3635622003203025e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0534.jpg\tCopien van resolutien tsedert; 21 Julij 1628. tet \t[0.000524799688719213, 0.998666524887085, 0.0008052625344134867, 3.4743839023576584e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0535.jpg\tberockt ons alsoo weder werck, geeft ons de handen\t[0.00047077046474441886, 0.9986982345581055, 0.0008276932057924569, 3.2896382435865235e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0536.jpg\tgewacht, dat sulcx de ongelegentheijt van tijt, en\t[0.000457533955341205, 0.9987055063247681, 0.0008337534964084625, 3.237969167457777e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0537.jpg\tDen 22.en s=o vertrocken van lato ende Holoij, end\t[0.00045695199514739215, 0.9987030029296875, 0.0008367759874090552, 3.2347047635994386e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0538.jpg\tdit geweest sijn, hebben nu inder daatr bevonden, \t[0.0004614722856786102, 0.9986867308616638, 0.0008485791622661054, 3.259247478126781e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0539.jpg\tende gewillich aengenomen, hadden mede al begonnen\t[0.0004731345397885889, 0.9985716342926025, 0.0009519452578388155, 3.2703010219847783e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0540.jpg\tDen 6. H=o Ist fargatt Suratte, Wederom op Amboijn\t[0.0005657071596942842, 0.9982045888900757, 0.0012259373906999826, 3.849762379104504e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0541.jpg\tOuer het Verlies van Rommite, hadden ouer Hittoe, \t[0.0007319174474105239, 0.9970439076423645, 0.0022183102555572987, 5.8309406085754745e-06]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1088_0542.jpg\twaren, het selue achter nelis hoeck te brengen, om\t[0.00012539722956717014, 0.0005359701463021338, 0.9993280172348022, 1.0601354915706906e-05]\n"
+      "BEGIN\tIN\tNL-HaNA_1.04.02_3577_0713.jpg\tintermen van klem vermaand in deezen 't zijne met \t[0.9999111890792847, 6.942303298274055e-05, 1.7352729628328234e-05, 1.954658046088298e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0714.jpg\toudstens te neemen, om niet door zulke vijandelijk\t[0.001180727151222527, 0.9981112480163574, 0.0006211033323779702, 8.702724153408781e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0715.jpg\thier toe dover eene Ernstige aanspraak aangespoord\t[0.0002669957175385207, 0.9994702935218811, 0.00023714298731647432, 2.5595105398679152e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0716.jpg\tvolbragt en in het Alphoirs gebergte van waijsamoe\t[0.0002059456892311573, 0.9994897842407227, 0.0002802750386763364, 2.396959280304145e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0717.jpg\tna de Negorij Tiehoelale welkers Orangkanj en scho\t[0.00016071864229161292, 0.9995928406715393, 0.00022814009571447968, 1.8367962184129283e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0718.jpg\tvervolgens aan het Huijs van den Orangkaij gekoome\t[0.00016177234647329897, 0.9995978474617004, 0.00021937639394309372, 2.099755329254549e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0719.jpg\tgezaghebbend oudsten zonder manquemant aan een bin\t[0.0001605066063348204, 0.9995991587638855, 0.00022289343178272247, 1.7514645151095465e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0720.jpg\tNeegen uuren weeder na Boord vertrok wanneer inmed\t[0.00015659107884857804, 0.9996058344841003, 0.0002185424673371017, 1.9076478565693833e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0721.jpg\topmerking geliefde te neemen hoe hij Padja Haloett\t[0.00015041464939713478, 0.9996155500411987, 0.00021648145047947764, 1.7497104636277072e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0722.jpg\ttoe geen andere uijt de mannelijke Linie meer gevo\t[0.00015816427185200155, 0.9996048808097839, 0.00021894570090807974, 1.7965938241104595e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0723.jpg\tbesteld zijnde, vertrock den wel Edele Agtb: Heer \t[0.00015841670392546803, 0.9995927214622498, 0.00022973060549702495, 1.9168248400092125e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0724.jpg\tte kunnen gaven daar zijn wel Edele Agtb: voor vre\t[0.00016308754857163876, 0.9996039271354675, 0.0002129876083927229, 2.0039278751937672e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0725.jpg\tNegorijen met verscheijde Basschoten begroet, nade\t[0.00014539275434799492, 0.9996263980865479, 0.00020987071911804378, 1.8351192920817994e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0726.jpg\twerwaards eenige vrouwlieden dansen de voor uijtgi\t[0.00016461338964290917, 0.9995895028114319, 0.00022829321096651256, 1.7680686141829938e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0727.jpg\tdaar door de spoedige verrotting en bederf der Aff\t[0.00014465753338299692, 0.9996275901794434, 0.00020977652457077056, 1.7989390471484512e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0728.jpg\twelke ged=e opperhoofd betuijgde mits de Compleere\t[0.00015955025446601212, 0.9995930790901184, 0.00022820370213594288, 1.9180544768460095e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0729.jpg\ten Ordonneerde in de eerstgem: een Nieuw Tafel en \t[0.0001498841302236542, 0.9996252059936523, 0.00020839976787101477, 1.640936352487188e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0730.jpg\tDen wel Edele Agtb: Heer Gouverneur recommandeerde\t[0.0001526533014839515, 0.9996175765991211, 0.0002120123099302873, 1.7738981114234775e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0731.jpg\tbewandelde zijn wel Edele Agtb: de sebve, en Zaij \t[0.00019400956807658076, 0.9995552897453308, 0.00023255583073478192, 1.8121270841220394e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0732.jpg\twoensdag den 1:e December, het noodige tot de Rijs\t[0.0001582333934493363, 0.999618411064148, 0.00020589558698702604, 1.7443138858652674e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0733.jpg\tkerken in schoolen van voortz: Negorijen die in ee\t[0.00014718755846843123, 0.9996225833892822, 0.00021222577197477221, 1.8000831914832816e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0734.jpg\tnarigt van den smokkelhandel der Cerammers, hun ko\t[0.00015289863222278655, 0.9996174573898315, 0.0002125836326740682, 1.700593566056341e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0735.jpg\tgeleegensheid het vervaardigen van een Nieuwe Lees\t[0.00017241972091142088, 0.9996044039726257, 0.00020308763487264514, 2.0160299754934385e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0736.jpg\tCruijpenning en eenige van het Hongij geselschap p\t[0.0001673312217462808, 0.9995971322059631, 0.0002175142290070653, 1.8015811292571016e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0737.jpg\tmitsg=s zodanig ook ten opzigte van de Capas Plant\t[0.00017430254956707358, 0.9995924830436707, 0.00021337448561098427, 1.9913011783501133e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0738.jpg\tdewelke een aanzienelijk, getal Boomptjes gevonden\t[0.00016666718875057995, 0.9996042847633362, 0.00021005528105888516, 1.905984572658781e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0739.jpg\tGodsdienst met het zingen van Psalm 118 vers 12: e\t[0.00016432785196229815, 0.9996053576469421, 0.0002125593600794673, 1.7697668226901442e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0740.jpg\tdaf met een meenigte van uuren verligt was op het \t[0.00016444249195046723, 0.9996064305305481, 0.00021012444631196558, 1.905770659504924e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0741.jpg\taangemoedigt tot de uijtbrijding dier Cultuure en \t[0.00015794656064826995, 0.9996111989021301, 0.00021256424952298403, 1.833247733884491e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0742.jpg\twel Edele Agtb: in Perzoon de Redout zo van buijte\t[0.00016993391909636557, 0.9996001124382019, 0.00021107675274834037, 1.892731961561367e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0743.jpg\tals hunne nakomelingen daar in opgeslooten met toe\t[0.00015404906298499554, 0.9996080994606018, 0.00021938449935987592, 1.852498644439038e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0744.jpg\tMaandag den 13: December, de 'smorgens wierd na Am\t[0.0001529883302282542, 0.9995993971824646, 0.000227884782361798, 1.977656575036235e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0745.jpg\twierden ter overvoer na Amboina; ook quam alhier d\t[0.00014719132741447538, 0.9996147155761719, 0.00022008399537298828, 1.8010236090049148e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0746.jpg\tden wel Edele Agtb: Heer Gouverneur van hier na de\t[0.00015096890274435282, 0.9996418952941895, 0.0001889034319901839, 1.827844971558079e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0747.jpg\thet Opperhoofd Cruijpenning als van D=l Scharff en\t[0.000162804193678312, 0.9996178150177002, 0.0002005086571443826, 1.8848542822524905e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0748.jpg\tstaven, wijl bereets d' gerequireerde sorteeringe \t[0.00015950683155097067, 0.9996316432952881, 0.0001904644159367308, 1.840009463194292e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0749.jpg\tintusschen quam omtrent tien uuren Haroekos Hoofd \t[0.0001460485509596765, 0.9996206760406494, 0.00021519340225495398, 1.8076041669701226e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0750.jpg\tdoor de besettelingen drie Chergues uijt het Hand \t[0.00015804993745405227, 0.9995960593223572, 0.00022743178124073893, 1.8523774997447617e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0751.jpg\theevig doleerden over de willekeelrige, en harde h\t[0.00014708047092426568, 0.9996347427368164, 0.0002009981544688344, 1.716578299237881e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0752.jpg\tFactuur van Primo Augustus J: L: Elf Guseliors gew\t[0.00013486476382240653, 0.9996212720870972, 0.0002267384552396834, 1.7170121282106265e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0753.jpg\teeven daar na vertoonde zig hier den gezaghebber v\t[0.00017091278277803212, 0.9996076226234436, 0.00020400255743879825, 1.7501401089248247e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0754.jpg\tvrugteloos bevonden was, terwijl des niet tegensta\t[0.0001503434614278376, 0.9996256828308105, 0.00020688182848971337, 1.705808608676307e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0755.jpg\tvan het Hoofd Treno, Deminbo, en kindertjes, en ve\t[0.0001735073165036738, 0.9995705485343933, 0.00023846088151913136, 1.7498718079878017e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0756.jpg\tdat gevaar te ontwijken des 'smorgens van daar afz\t[0.00015051348600536585, 0.9996229410171509, 0.00020700402092188597, 1.9557099221856333e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0757.jpg\tDHeer Gouverneur Rapport doen dat 'er op zijn Post\t[0.0001747384521877393, 0.9995934367179871, 0.00021260284120216966, 1.9133216483169235e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0758.jpg\twel Edele Agtbare Heer; Mij wel inhandigt zijnde u\t[0.00016309374768752605, 0.999620795249939, 0.00019756826804950833, 1.8449252820573747e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0759.jpg\tbeugels, onder Factuur van Aanreekening ter verand\t[0.00014928076416254044, 0.999566376209259, 0.0002659319434314966, 1.8397140593151562e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0760.jpg\tBoord gekoomen zijnde resolveerde den wel Edele Ag\t[0.00013841934560332447, 0.9996460676193237, 0.00019822987087536603, 1.7292562915827148e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0761.jpg\t„de vaartuijgen der vloot zo spoedig doenelijk lan\t[0.0001458551560062915, 0.9996060729026794, 0.00022939278278499842, 1.8680731955100782e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0762.jpg\tRegent en Posthouder, onder afwijsing van verschei\t[0.0001808766246540472, 0.9995610117912292, 0.00023734870774205774, 2.0747391317854635e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0763.jpg\tontfing, en de voornaamste onthaalde op eenige gla\t[0.0001463988737668842, 0.9996466636657715, 0.00018973357509821653, 1.7109110558521934e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0764.jpg\tNagezien.; 6; T; JD: V: Wieringer\t[0.00017076716176234186, 0.9995837807655334, 0.00022607551363762468, 1.9461336705717258e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0765.jpg\tDen wel Edele Agtbaare Heer; Gouverneur en Directe\t[0.00014800517237745225, 0.9996260404586792, 0.0002062605635728687, 1.9674360373755917e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0766.jpg\tvan vijf gaaren ingaande met p=mo November aanstaa\t[0.00014918176748324186, 0.9996201992034912, 0.00021394893701653928, 1.6731504729250446e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0767.jpg\ttot het behoud van het gering overgebleven getal b\t[0.00015806405281182379, 0.9995880722999573, 0.0002345672546653077, 1.925432479765732e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0768.jpg\tdoor het Hoofd Galloo gedaan verzoek om van het sc\t[0.00018042183364741504, 0.9995983242988586, 0.00020005054830107838, 2.1250321879051626e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0769.jpg\tGalloo gelast om bij de vlaggd stok op 't gebergte\t[0.00015341490507125854, 0.9996237754821777, 0.0002037573722191155, 1.901294308481738e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0770.jpg\tDen wel Edele Agtbaare Heer; Gouverneuren Tiracteu\t[0.0001575399364810437, 0.9996045231819153, 0.0002201050374424085, 1.7860153093351983e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0771.jpg\tFiscaal Haga gevisiteerd zijnde het alhier beruste\t[0.0001737340062391013, 0.9995562434196472, 0.00025077653117477894, 1.919788155646529e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0772.jpg\tNegorij Bonoa weeder te vervullen met den daar om \t[0.0001621000556042418, 0.99958735704422, 0.00023178565606940538, 1.8725277186604217e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0773.jpg\tSepalatoe gen=t, die reets een geruijmen tijd als \t[0.0001674404920777306, 0.999580442905426, 0.00023230057558976114, 1.97374502022285e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0774.jpg\tVermaanende zijn wel Edele Agtb: voorsz: Regenten \t[0.00016172001778613776, 0.9995002746582031, 0.00031835463596507907, 1.966910895134788e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0775.jpg\tDag register recommandeerde zijn wel Edele Agtb: v\t[0.00025551102589815855, 0.9962653517723083, 0.003438530955463648, 4.063548112753779e-05]\n",
+      "END\tIN\tNL-HaNA_1.04.02_3577_0776.jpg\tAlverder ordonneerde den Heer Gouverneur de Regent\t[3.592299617594108e-05, 0.00018315129273105413, 0.9997778534889221, 3.1299875900003826e-06]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_3577_0777.jpg\thun eigen toe doen zijn wel Edele Agtb: hoope om h\t[0.9998897314071655, 8.585154864704236e-05, 2.1891924916417338e-05, 2.434436282783281e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0778.jpg\tde Regenten door een vriendelijke vermaaning op we\t[0.0007666017627343535, 0.9987285733222961, 0.00044200263801030815, 6.283319817157462e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0779.jpg\teene plegtige submissie der Cerammers in deese Cre\t[0.0004403045168146491, 0.9991607666015625, 0.000364844425348565, 3.4104741644114256e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0780.jpg\tvan een vergadering bij den anderen zijn geweest, \t[0.00019445632642600685, 0.9995589852333069, 0.0002243690105387941, 2.2176041966304183e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0781.jpg\tDen wel Edele Agtb: Heer Gouverneur deze vergaderi\t[0.00017439939256291837, 0.9995566010475159, 0.00024756084894761443, 2.139933712896891e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0782.jpg\ten door zijn Broeders zoon Bariend gesuccedeert te\t[0.0001939054491231218, 0.9995908141136169, 0.0001939683425007388, 2.1380137695814483e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0783.jpg\tJanuarij 1774: vi de vonnis van den Land Raad voor\t[0.00016076468455139548, 0.9996064305305481, 0.00021651208226103336, 1.6338395653292537e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0784.jpg\ten reparatie na het Hoofd Casteel te zenden;; Door\t[0.00015516509301960468, 0.9996310472488403, 0.00019470695406198502, 1.9026287191081792e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0785.jpg\tRegenten van Bouro en Amblauw op het ernstigste; g\t[0.00015793995407875627, 0.9995961785316467, 0.00022679071116726846, 1.904920645756647e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0786.jpg\tder andere subalterne Comptoiren van dit Gouvernem\t[0.00015177491877693683, 0.9996185302734375, 0.00021063804160803556, 1.9031891497434117e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0787.jpg\tdie geleegendheid de allernaauwste recherge te doe\t[0.00015002532745711505, 0.9996283054351807, 0.00020451053569559008, 1.7210191799676977e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0788.jpg\tAldus Gedaan en Geresolveert ten Comptoire; Douro \t[0.0001556400238769129, 0.9996240139007568, 0.00020244612824171782, 1.7865986592369154e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0789.jpg\tZacharias Sierborij van Poorto oud 24:e willem Man\t[0.00016701500862836838, 0.9995805621147156, 0.00023394175514113158, 1.8455284589435905e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0790.jpg\tte bestieren en de hof en Heere diensten daar door\t[0.00016730031347833574, 0.9995773434638977, 0.00023743091151118279, 1.7833217498264275e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0791.jpg\tZuijd; over de Negorij Laimoe aan Cerams Oost Cust\t[0.00016945759125519544, 0.9995951056480408, 0.00021640498016495258, 1.909188722493127e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0792.jpg\tjarige ouderdom als ook 566: lb: Moernagulen die a\t[0.00014020288654137403, 0.9996418952941895, 0.00020171893993392587, 1.617275847820565e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0793.jpg\tIntusschen matige wij ons d'eer van in alle onderd\t[0.0001511963055236265, 0.9996384382247925, 0.00019381099264137447, 1.660581438045483e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0794.jpg\tJatij Capes; Dat door den ondergeteekende; 754 8 b\t[0.0001392880076309666, 0.9996345043182373, 0.00020918781228829175, 1.7040463717421517e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0795.jpg\tDuursteede den 10 Decem¬; /:onderstond/ Caparoua; \t[0.0001547877909615636, 0.9996141195297241, 0.00021138592273928225, 1.967134994629305e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0796.jpg\tOp de ingebragte klagte van den Radja over de Nego\t[0.0001585746358614415, 0.9996029734611511, 0.00022066208475735039, 1.7772808860172518e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0797.jpg\tRapport Aan Den wel Edelen Agtbaare Heer; Bernardu\t[0.0001495395554229617, 0.9996181726455688, 0.0002157390263164416, 1.6598007277934812e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0798.jpg\tBernardus van Pleuren; Gouverneur en Directeur des\t[0.00014311358972918242, 0.9996362924575806, 0.00020288368978071958, 1.777233228494879e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0799.jpg\tden Jnlander betaald worden, om de Noots en foelij\t[0.00018193900177720934, 0.9996036887168884, 0.0001931525330292061, 2.125556602550205e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0800.jpg\teen en ander in overweging genomen zijnde wierd no\t[0.00015208568947855383, 0.9996289014816284, 0.00020040383969899267, 1.8577689843368717e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0801.jpg\tLaastelijk wierd verstaan aantekeening te houden d\t[0.00014806812396273017, 0.9996240139007568, 0.00021008568000979722, 1.778343903424684e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0802.jpg\tDen wel Edele Agtb: Heer Gouverneur de vergadering\t[0.0001655017549637705, 0.9995909333229065, 0.00022322492441162467, 2.0413255697349086e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0803.jpg\tder Negorij Sameth te ontslaan onder toevoeging va\t[0.00015276935300789773, 0.9995936751365662, 0.00023439325741492212, 1.922315095725935e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0804.jpg\tdat in het Alphoers gebergte van waijsammoe eenige\t[0.00016996551130432636, 0.9995934367179871, 0.0002174736000597477, 1.924236858030781e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0805.jpg\tSwaijsama en aldaar des nademiddags om 3 uuren aan\t[0.00014826619008090347, 0.9996142387390137, 0.00022015378635842353, 1.7300457329838537e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0806.jpg\tvervolgens wierd verstaan in deesen, aanteekening \t[0.00014617148553952575, 0.999626636505127, 0.00020908068108838052, 1.810174944694154e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0807.jpg\tGouverneur op de Negorij na het: Hoofd Casteel, ov\t[0.00014844394172541797, 0.9996250867843628, 0.00020861469965893775, 1.7907217625179328e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0808.jpg\tdie van Camariang, Thiolale en Rumakaij in een bee\t[0.00016217204392887652, 0.9994534850120544, 0.0003650602884590626, 1.9305618479847908e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_3577_0809.jpg\tRapport Aan den wel Edelen Agtbare Heer; Bernardus\t[0.0002469525206834078, 0.9973010420799255, 0.0024131066165864468, 3.887200728058815e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_3577_0810.jpg\tAgtb: gehoorsame en Trouwschuldige Dienaar /:was g\t[3.34670658048708e-05, 0.00017428057617507875, 0.9997895359992981, 2.726402954067453e-06]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0468.jpg\t\t[0.00011624029139056802, 0.0003206664405297488, 5.2529136155499145e-05, 0.999510645866394]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0469.jpg\t\t[3.03311062452849e-05, 6.571004632860422e-05, 1.2811156011593994e-05, 0.9998911619186401]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0470.jpg\t\t[3.2013213058235124e-05, 5.6304394092876464e-05, 1.600748328201007e-05, 0.9998956918716431]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0471.jpg\tVrijdagh den 26; November Ao 1694; Den raad door d\t[0.999392032623291, 8.434362825937569e-05, 6.473267421824858e-05, 0.00045894048525951803]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0472.jpg\tdie reets in steede van 't. fregatje de bije sorde\t[0.01732778549194336, 0.9613315463066101, 0.0021330693271011114, 0.019207581877708435]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0473.jpg\tEn nogh voor batavia —; 1049½ elj: diverse laacken\t[0.0027374119963496923, 0.9944861531257629, 0.000768540776334703, 0.002007876755669713]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0474.jpg\tIn't schip Silversteijn—; 103729. lb: Comeijn te w\t[0.0006954167620278895, 0.9987841248512268, 0.0003520473255775869, 0.00016842660261318088]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0475.jpg\t20: packen gesies —; 22.. „ d„o kassen; 6. „ alegi\t[0.0002429962914902717, 0.9994581341743469, 0.0002523630973882973, 4.649821494240314e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0476.jpg\tpackhuijsen alhier overleggen, tot tijt en wijle; \t[0.00017047453729901463, 0.9995740056037903, 0.00022795442782808095, 2.7501784643391147e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0477.jpg\t'tschip silversteijn belaaden met d'overige; goede\t[0.00017467353609390557, 0.9995718598365784, 0.00022471239208243787, 2.8752021535183303e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0478.jpg\tvoor als nogh hier t komen, ten ware men op zijn; \t[0.00013509171549230814, 0.9994650483131409, 0.0003717090585269034, 2.8113821826991625e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0479.jpg\tgevalideert soo is hem sulcx als een billuke; saac\t[0.0001919697824632749, 0.9974833130836487, 0.0022822353057563305, 4.243432340444997e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0480.jpg\twas geteeck:t adriaan van ommen; Pr: Coesaart: D„s\t[3.063990516238846e-05, 0.00017870079318527132, 0.9997867941856384, 3.879640644299798e-06]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0644.jpg\t\t[0.00013152690371498466, 0.00026836578035727143, 5.184346082387492e-05, 0.9995482563972473]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0645.jpg\t\t[2.3593100195284933e-05, 4.5784243411617354e-05, 8.651566531625576e-06, 0.9999219179153442]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0646.jpg\t\t[1.3783057511318475e-05, 3.124208524241112e-05, 6.893964382470585e-06, 0.9999481439590454]\n",
+      "OUT\tBEGIN\tNL-HaNA_1.04.02_1547_0647.jpg\t\t[2.2105656171333976e-05, 4.131983587285504e-05, 1.2794467693311162e-05, 0.9999237060546875]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1547_0648.jpg\tNotitie Dan Alle De Coopmanz; 8863 -. „; 62880 – „\t[0.9983628392219543, 0.00010535342153161764, 8.358713239431381e-05, 0.0014483022969216108]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0649.jpg\tkosten als mede 't bedragen van de Geheele Verkogt\t[0.0195121169090271, 0.9327102899551392, 0.0023733568377792835, 0.04540421813726425]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0650.jpg\t120¾ lb geel plaatkoper - - - - - - - - - - - - - \t[0.003090029349550605, 0.9818441271781921, 0.0018111321842297912, 0.013254761695861816]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0651.jpg\tadvancen opde advancen perC=to; monteerende van 't\t[0.0037490855902433395, 0.9406869411468506, 0.04157562181353569, 0.013988303951919079]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0652.jpg\t\t[0.004719235934317112, 0.8539608716964722, 0.009736822918057442, 0.1315830647945404]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0653.jpg\t\t[0.0038672741502523422, 0.5670512914657593, 0.00945170409977436, 0.41962969303131104]\n",
+      "OUT\tIN\tNL-HaNA_1.04.02_1547_0654.jpg\t\t[0.002077607437968254, 0.13720057904720306, 0.0030319523066282272, 0.8576898574829102]\n",
+      "OUT\tIN\tNL-HaNA_1.04.02_1547_0655.jpg\t\t[0.0009797499515116215, 0.049220744520425797, 0.0006607329705730081, 0.9491387605667114]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1547_0656.jpg\t127½ lb bengaalse amphioen - - . ..; 23475- „ Japp\t[0.9917135238647461, 0.004740198142826557, 0.000450287654530257, 0.0030959835276007652]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0657.jpg\tweel; danige Coopmansz Ulser Sedert P=mo Januarij \t[0.009500839747488499, 0.8288524150848389, 0.12808509171009064, 0.03356161713600159]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0658.jpg\t\t[0.005053464788943529, 0.6023523211479187, 0.009728998877108097, 0.38286519050598145]\n",
+      "OUT\tIN\tNL-HaNA_1.04.02_1547_0659.jpg\t\t[0.002451798878610134, 0.11830917745828629, 0.0021089499350637197, 0.8771300911903381]\n",
+      "BEGIN\tIN\tNL-HaNA_1.04.02_1547_0660.jpg\thet Bedragen va; Randeles Partije 1500; Indische H\t[0.9844396114349365, 0.014215805567800999, 0.0009135378058999777, 0.000431054417276755]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0661.jpg\tser Comptoir voor Contands geles sedert Primo Janu\t[0.00016300412244163454, 0.00030706607503816485, 0.999406099319458, 0.0001238318654941395]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_2970_0278.jpg\tWoensdag den 18' Juny Ao 1760; op; Middelerwyle wi\t[0.9998658895492554, 9.465996117796749e-05, 3.5563018172979355e-05, 3.966170424973825e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0279.jpg\tde Edele agtb: heere Weesmeesteren tot Amsterdam; \t[0.0005732171703130007, 0.9980097413063049, 0.0013303037267178297, 8.6716674559284e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0280.jpg\tExtract uyt de mis¬; sive door heeren Weesmees; te\t[0.00065391551470384, 0.9806766510009766, 0.01850888319313526, 0.00016046590462792665]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0281.jpg\t\t[0.0006141855265013874, 0.9937678575515747, 0.004916029516607523, 0.0007019492331892252]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0282.jpg\t\t[0.0013639371609315276, 0.9922803640365601, 0.004319575149565935, 0.002036122838035226]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0283.jpg\tD Testamentaire Erfgen: va; Jacomina Chasse wed Gr\t[0.0005438720691017807, 0.9988420605659485, 0.000563774083275348, 5.041211625211872e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0284.jpg\tP=r Transport rd=s 11. 100:—; Den boedel van Jacom\t[0.00019986835832241923, 0.9993472695350647, 0.00042188071529380977, 3.0974213586887345e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_2970_0285.jpg\tPr Transport r=os 16:8; Transport d„s 1228 12; Om \t[0.00019531916768755764, 0.99724942445755, 0.0025212476029992104, 3.395889507373795e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_2970_0286.jpg\tnagelien; J Schilbmnar; Notitie van diversche pa; \t[2.2145139155327342e-05, 0.0001450798736186698, 0.9998304843902588, 2.2129611352283973e-06]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 62%|██████▏   | 7/11.3125 [00:07<00:05,  1.21s/batch]"
+      "100%|██████████| 24/24 [00:01<00:00, 14.57batch/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1088_0543.jpg\t244; voorganis, datmen ons niet en mocht vertrouwe\t[0.9996716976165771, 0.0002440052921883762, 5.560545832850039e-05, 2.864483576558996e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0544.jpg\tvrouw, den man niet mede toebehoorde, niet meer an\t[0.0013026803499087691, 0.9975475668907166, 0.0011445655254647136, 5.290075478114886e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0545.jpg\tsoete middelen te werck gaen, hoewel daar mede nie\t[0.000736430985853076, 0.9982445240020752, 0.0010156105272471905, 3.414582806726685e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0546.jpg\tsoude mogen bewaert leggen, maer alst nu alsoo bes\t[0.0006624372908845544, 0.998327910900116, 0.0010065833339467645, 3.124250497421599e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0547.jpg\tsij seijden dat op Hattamana, den Jongen Coninck, \t[0.0006504838238470256, 0.9983435869216919, 0.0010027886601164937, 3.0803296340309316e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0548.jpg\tuijt de quartieren van hittoe, dit heele Mosson, m\t[0.0006729831220582128, 0.9983543157577515, 0.0009696476627141237, 3.129384595013107e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0549.jpg\tdaer van wachten soude, hebben de gevangenen ontsl\t[0.0006439752178266644, 0.9982763528823853, 0.0010766031919047236, 3.1295940061681904e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0550.jpg\thebben geconsenteert, haer best te doen, ende reve\t[0.0006456052651628852, 0.9982292056083679, 0.0011220307787880301, 3.1833753837418044e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0551.jpg\tselffs dootlijck gewont, waar op die van Cambello \t[0.000643562467303127, 0.9981923699378967, 0.0011608133791014552, 3.2136783829628257e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0552.jpg\tspoedich affhandelen, ende ons laeten weeten, waer\t[0.0006327332812361419, 0.9981871247291565, 0.0011769258417189121, 3.1538636449113255e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0553.jpg\tpattij naij, met haer souden afsenden, om den Coni\t[0.0006450952496379614, 0.9981984496116638, 0.0011532953940331936, 3.1781326015334344e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0554.jpg\tbegeerden alleen te verstaen, wat antwoort den kim\t[0.0006323644774965942, 0.9981972575187683, 0.0011673056287690997, 3.137434759992175e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0555.jpg\tsij hadden geseijt voor ons bevreest te weesen, en\t[0.0006447727209888399, 0.9982115030288696, 0.0011405465193092823, 3.1629288059775718e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0556.jpg\tTarnataensen aenhanck, vande custe van Ceram: niet\t[0.0006336785736493766, 0.9982084035873413, 0.0011548417387530208, 3.127799345747917e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0557.jpg\top houden, conde niet bedencken wat Excusien sij d\t[0.0006333737983368337, 0.9982457160949707, 0.0011178076965734363, 3.0894120754965115e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0558.jpg\tvereenichde Nederlanden, maer deselue hebben haren\t[0.0006291400059126318, 0.9981916546821594, 0.0011761009227484465, 3.115921572316438e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0559.jpg\tte werden, het welck wij hebben naergecommen, ende\t[0.0006258258363232017, 0.9981827735900879, 0.00118834909517318, 3.119759185210569e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0560.jpg\ttraecheijt des Conincx van Saulauw, niet en soude \t[0.0006248016143217683, 0.9981860518455505, 0.0011860891245305538, 3.1027441309561254e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0561.jpg\top dat alsoo de oude vruntschap, mocht vernieuwt w\t[0.0006235522450879216, 0.9981833100318909, 0.0011899573728442192, 3.1006238714326173e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0562.jpg\tarmoede die zijn bolck leet, doch ten laetsten hei\t[0.0006269865552894771, 0.9981860518455505, 0.001183861750178039, 3.108519649686059e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0563.jpg\tte assisteeren.; Capn. Hittoe quam ons mede besoec\t[0.0006210214924067259, 0.9981801509857178, 0.0011957986280322075, 3.0843812055536546e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0564.jpg\tHebben den gesant Noffa Maniera, bij ons ontbooden\t[0.0006196658359840512, 0.9981772899627686, 0.0011999757261946797, 3.074886080867145e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0565.jpg\tgoetgevoelen vandese saack; Wij Eijschten vanden g\t[0.0006176775204949081, 0.9981793165206909, 0.001199985621497035, 3.0709593374922406e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0566.jpg\tDit staat ons vreemt aen, connes oock niet geloove\t[0.0006274364423006773, 0.9981719255447388, 0.0011975679080933332, 3.0950491236581e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0567.jpg\tworden, met veel meer schoone woorden daar noch bi\t[0.0006245552212931216, 0.9981446266174316, 0.001227743225172162, 3.108811597485328e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0568.jpg\tnaar Hittoe, aenden ondercoopman vant Nederlants C\t[0.0006667859270237386, 0.9979243278503418, 0.0014055630890652537, 3.372686478542164e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1088_0569.jpg\tdat denselven soude doen translateren, op dat aen \t[0.0009438418201170862, 0.9958733916282654, 0.00317723979242146, 5.5447162594646215e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1088_0570.jpg\tende geen meer en haddent, schreeff Helenij aen on\t[0.00011120597628178075, 0.00034481132752262056, 0.9995362758636475, 7.70642509451136e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 71%|███████   | 8/11.3125 [00:08<00:03,  1.12s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8099_0205.jpg\tVan Ternaten onder dato 11:' 7ber: 1732; van alle \t[0.9996312856674194, 0.0002860643435269594, 5.3606450819643214e-05, 2.9019489375059493e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0206.jpg\tVan Ternaten onder dato 11:' Septemb:r 1732; Lauwt\t[0.0012760489480569959, 0.9975454211235046, 0.0011733275605365634, 5.199290171731263e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0207.jpg\tVan Ternaten onder dato 11:' 7ber: 1732; door hem \t[0.0007270185160450637, 0.99822598695755, 0.0010435982840135694, 3.4044653602904873e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0208.jpg\tTernaten onder dato 11:' 7ber: 1732; Van; „dugting\t[0.0006661674124188721, 0.9983421564102173, 0.000988578307442367, 3.148679070363869e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0209.jpg\tTernaten onder dato 11:' 7ber: 1732; Van; Ternaten\t[0.0006602519424632192, 0.9983484745025635, 0.0009882479207590222, 3.1223669338942273e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0210.jpg\tTernaten onder dato 11:' Sepb: 1732; Van; voor ops\t[0.0006329501629807055, 0.9983215928077698, 0.0010424710344523191, 3.014485400854028e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0211.jpg\tTernaten onder dato 17:' 7ber: 1732; E; Van; en we\t[0.0006278455257415771, 0.9983351826667786, 0.0010340239387005568, 2.9740178888459923e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0212.jpg\tVan Ternaten onder dato 11:' Jber: 1732; Saturdag \t[0.0006291165482252836, 0.9983553290367126, 0.0010125287808477879, 2.9532704957091482e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0213.jpg\tVan Ternaten onder dato 11:' Jber: A„o 1732; AAan \t[0.0006303767440840602, 0.9983378648757935, 0.0010287839686498046, 2.9729740163020324e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0214.jpg\tVan Ternaten onder dato 11:' Septemb: A„o 1732; ee\t[0.0006384073640219867, 0.9982411861419678, 0.0011173522798344493, 3.0961286938691046e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0215.jpg\tVan Ternaten onder dato 11:' Septemb: 1732; waar v\t[0.0006639689090661705, 0.9979673027992249, 0.0013653250643983483, 3.383792318345513e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8099_0216.jpg\tTernaten onder dato 11:' 7ber: A„o 1732; Van; uijt\t[0.0009230943396687508, 0.9954870343208313, 0.003584187012165785, 5.737602805311326e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_8099_0217.jpg\tVan Ternaten onder dato 11:' Septemb: 1732; s geli\t[0.00011093446664744988, 0.00034825963666662574, 0.9995331764221191, 7.678319889237173e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 80%|███████▉  | 9/11.3125 [00:08<00:02,  1.08batch/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1070_0199.jpg\t2 saeckers Elck van 3000 lb; 2 halve dittos elck v\t[0.9980164766311646, 0.0011951117776334286, 0.0004300513246562332, 0.00035834635491482913]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1070_0200.jpg\t\t[0.0033359762746840715, 0.9911088943481445, 0.002743801102042198, 0.002811391605064273]\n",
-      "IN\tEND\tNL-HaNA_1.04.02_1070_0201.jpg\tAdriaen gerritsz van utrecht sergiant; marijn Ding\t[0.008283664472401142, 0.8976438045501709, 0.09393522888422012, 0.00013724264863412827]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 88%|████████▊ | 10/11.3125 [00:10<00:01,  1.23s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1509_1538.jpg\tMonsterolle van alle sComp:s Loontreckende; Monste\t[0.9996657371520996, 0.0002513462968636304, 5.458337182062678e-05, 2.8321261197561398e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1539.jpg\tdienaren dewelcke in't Cormandelse Gouvernement bi\t[0.001239656237885356, 0.9975988268852234, 0.0011563834268599749, 5.0744920372380875e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1540.jpg\t339. en 35. persoonen p=r Transport. —; Namen, Toe\t[0.0007339020376093686, 0.9982773065567017, 0.000985415535978973, 3.334223038109485e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1541.jpg\t90; d=o.. . ..; Adsistent; Chirurgijn. . . . ƒ 36.\t[0.0006549559766426682, 0.9983497858047485, 0.0009921861346811056, 3.074438154726522e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1542.jpg\t339 en 74. persoonen P=r Transport; Namen, Toename\t[0.0006838284898549318, 0.9983718991279602, 0.0009412301005795598, 3.1212073281494668e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1543.jpg\tsiekevaar. . . ƒ 20. walcheren. . . . . 1662. Zeel\t[0.0006473595276474953, 0.9983565211296082, 0.000993035384453833, 3.036265070477384e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1544.jpg\t339. en 113. persoonen P=r Transport.; Namen, Toen\t[0.00063288863748312, 0.9983593821525574, 0.001004778896458447, 2.969991783174919e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1545.jpg\tp:l timmerman. ƒ 11. d' bergh China. . . 1682. Ams\t[0.000654469826258719, 0.9983716607093811, 0.0009709415026009083, 3.0092189717834117e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1546.jpg\t339. en 155. persoonen P=r Transport; 1. Abraham f\t[0.0006219803472049534, 0.9983568787574768, 0.0010181806283071637, 2.9162526971049374e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1547.jpg\t90; 90; 90; 90; D=o; d=o; 90; D=o; 90; 90; D=o; D=\t[0.0006546429940499365, 0.9983752965927124, 0.0009670706349425018, 2.977298890982638e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1548.jpg\t339. en 195. persoonen P=r Transport —; Namen, Toe\t[0.0006408162880688906, 0.9983689188957214, 0.0009873026283457875, 2.9449377052515047e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1549.jpg\t90; 90; 90; 40; 90; D=; D=o; D=o; D=o; D=o; D=o; 9\t[0.000621116952970624, 0.9983568787574768, 0.0010191069450229406, 2.9039415494480636e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1550.jpg\t339. en 236. persoonen p=r Transport; Namen, Toena\t[0.0006209887797012925, 0.9983565211296082, 0.0010196373332291842, 2.900132358263363e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1551.jpg\tdo.; 90; do; 90; do; do; 90; 90; 90; D=o. . . . „;\t[0.0006199268973432481, 0.9983583092689514, 0.001018935232423246, 2.899922037613578e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1552.jpg\t339. en 278. persoonen P=r Transport; Namen, Toena\t[0.0006503808544948697, 0.9983755350112915, 0.0009711466846056283, 2.959453922812827e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1553.jpg\tw:t p:r met wat schip in india; presente qualitijt\t[0.0006205200334079564, 0.9983571171760559, 0.0010194774949923158, 2.8985857625229983e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1554.jpg\t339. en 320. persoonen p=r Transport; Namen, Toena\t[0.0006219208589754999, 0.9983585476875305, 0.0010167122818529606, 2.8993031264690217e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1555.jpg\tCommand:r te water en te; noorder Cormandel; „coop\t[0.0006171274580992758, 0.9983555674552917, 0.0010244391160085797, 2.8856841254309984e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1556.jpg\t356. persoonen p=r Transport; Namen toenamen en ge\t[0.0006180928903631866, 0.9983566403388977, 0.0010223871795460582, 2.8807789931306615e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1557.jpg\tw:t p:r met wat schip in jndia..; presente qualiti\t[0.0006177755421958864, 0.9983567595481873, 0.0010225330479443073, 2.8885124265798368e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1558.jpg\t391. persoonen p:r transport; Namen, Toenamen, en \t[0.0006166246021166444, 0.9983578324317932, 0.0010226486483588815, 2.8809390641981736e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1559.jpg\tw:t p:r met wat schip in; presente qualitijt. maen\t[0.0006184214144013822, 0.9983540773391724, 0.0010246264282613993, 2.8859990379714873e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1560.jpg\tNamen Toenamen en Geboorte plaatsen; 1. bastiaan I\t[0.0006180882919579744, 0.9983578324317932, 0.0010212593479081988, 2.88676983473124e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1561.jpg\tw:t p:r met wat schip in jndia/; presente qualitij\t[0.0006156605668365955, 0.9983575940132141, 0.0010238527320325375, 2.8753993319696747e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1562.jpg\t464. persoonen p:r transport; Namen Toenamen en Ge\t[0.0006167965475469828, 0.9983571171760559, 0.0010231551714241505, 2.8833778742409777e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1563.jpg\tp:r coopm: en opperh:t van; tegenep: en p:r novo: \t[0.0006195646128617227, 0.9983536005020142, 0.0010240058181807399, 2.893173586926423e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1564.jpg\t504. persoonen p=r Transport; Namen, Toenamen, en \t[0.0006254959153011441, 0.9983232617378235, 0.0010481951758265495, 2.9282271043484798e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1565.jpg\tw:t p:r met wat schip in; presente qualitijt maent\t[0.00067210040288046, 0.9981207251548767, 0.0012038942659273744, 3.1878291792963864e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1509_1566.jpg\tOp Nagapatnam zijn nogh bescheijden d'volgende; Bo\t[0.0009380431729368865, 0.9964576363563538, 0.0025993590243160725, 5.031526143284282e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1509_1567.jpg\t103 en 84. persoonen p:r transport; 1. toatongoe v\t[0.0001313278917223215, 0.0004021788772661239, 0.9994580149650574, 8.483448254992254e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 97%|█████████▋| 11/11.3125 [00:13<00:00,  1.77s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1490_0583.jpg\tCopije Secrete Resolutien; genomen bij de Ho: Rege\t[0.9996656179428101, 0.0002538571716286242, 5.294060247251764e-05, 2.766472243820317e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0584.jpg\tin presentie; van zijn Ed. t te; volbrengen, soo s\t[0.0012668200070038438, 0.9975445866584778, 0.0011833261232823133, 5.190873253013706e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0585.jpg\tdat 's Comp. s dienaren en wel voorna„; mentlijk p\t[0.0007265448803082108, 0.9982732534408569, 0.0009968261001631618, 3.3520634588057874e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0586.jpg\tbij ons te boeck staen voor niet wel; geintentione\t[0.0006719699595123529, 0.9983534812927246, 0.0009714624029584229, 3.1505230708717136e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0587.jpg\tgoetgevonden dat dese ontbiedinge; bij ons gemeen \t[0.0006590731791220605, 0.9983616471290588, 0.0009761892142705619, 3.1130866773310117e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0588.jpg\tschaap harder herwaerts aen te doen; overkomen, ge\t[0.0006577562307938933, 0.9983550906181335, 0.0009840548736974597, 3.1000397484604036e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0589.jpg\tmilitie daer in te houden in goede; ordre soo is v\t[0.0006411481881514192, 0.9983574748039246, 0.000998393865302205, 3.0138292004266987e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0590.jpg\tdertig of veertigh persoonen ten; hoogsten; genome\t[0.0006400620914064348, 0.9983604550361633, 0.0009964691707864404, 3.007888381034718e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0591.jpg\twillem van outhoorn, wouter; valkenier, abraham va\t[0.0006397810648195446, 0.9983595013618469, 0.0009977606823667884, 3.005955932167126e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0592.jpg\tsijner goet staende maentgelden; en verdere annexe\t[0.0006385218002833426, 0.9983605742454529, 0.0009979187743738294, 3.0011240141902817e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0593.jpg\tmaer sijne valsche betigters; en aenklagers tumput\t[0.000645994849037379, 0.9983643889427185, 0.000986626953817904, 3.013062496393104e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0594.jpg\taen uwe Edelhedens, niet; demoedig versoeck, dat u\t[0.0006371470517478883, 0.9983605742454529, 0.0009992739651352167, 2.994636815856211e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0595.jpg\tacte van herstellinge en verdere; ten desen dienen\t[0.0006402351427823305, 0.9983566403388977, 0.001000152318738401, 2.9996699595358223e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0596.jpg\ten omme de france vijanden, soo der; eenige quamen\t[0.0006359116523526609, 0.9983590245246887, 0.0010020154295489192, 2.9870052458136342e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0597.jpg\tde ridderschap voerende 60. stucken ges:t; waterla\t[0.0006360727711580694, 0.9983534812927246, 0.0010074685560539365, 2.9669874948012875e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0598.jpg\tstierlijk pennisten, kranckbesoekers; en chirurgij\t[0.0006283663096837699, 0.9983598589897156, 0.001008728751912713, 2.9394143439276377e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0599.jpg\tvan hier nevens „200.; en uijt 170. Comp:s lijfeij\t[0.0006252375314943492, 0.9983664155006409, 0.0010055446764454246, 2.9153879950172268e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0600.jpg\tsterck 1662. Coppen, daer onder; gerekent, de oude\t[0.0006513104890473187, 0.9983715415000916, 0.0009741550893522799, 2.9891341455368092e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0601.jpg\tbleven met 70. â 80. jnlanders, als; mede ongevaer\t[0.0006280566449277103, 0.9983575940132141, 0.0010113875614479184, 2.9419766178762075e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0602.jpg\tsodanig quame te vereijsschen, ende; sonder dat ie\t[0.0006310389726422727, 0.998358428478241, 0.0010075909085571766, 2.9464631552400533e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0603.jpg\tveranderinge ofte bijvoeginge diende; te geschiede\t[0.0006265107658691704, 0.9983532428741455, 0.0010172664187848568, 2.9217371775303036e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0604.jpg\tdiscoureren en te verklaren hoe; dat hij bij sig s\t[0.0006250430014915764, 0.9983550906181335, 0.0010169099550694227, 2.9288230507518165e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0605.jpg\tquamen overvallen en aentasten:; soo meende sijn E\t[0.0006212848820723593, 0.9983564019203186, 0.0010194826172664762, 2.906475401687203e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0606.jpg\tdeselve niet ten proije mogten werden,; wanneer on\t[0.0006196452886797488, 0.998357355594635, 0.0010200910037383437, 2.898404090956319e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0607.jpg\tvan meerdere versekeringe mogten; oordelen behoord\t[0.000620724109467119, 0.99835604429245, 0.001020309398882091, 2.903130734921433e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0608.jpg\tvanden Command:r Sijmon vander; stel, en raed aend\t[0.000619244878180325, 0.9983580708503723, 0.0010197954252362251, 2.8970518997084582e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0609.jpg\talthans te deser rhede leggende; zeemagt wel van e\t[0.0006209546118043363, 0.9983539581298828, 0.0010222658747807145, 2.901192601711955e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0610.jpg\tvan het verleden Iaer, als wanneer; volgens het sp\t[0.0006279792869463563, 0.998332679271698, 0.0010363407200202346, 2.9264288059493992e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0611.jpg\twas, onaengesien het goet succes; der negotie veel\t[0.0006686467677354813, 0.9981945157051086, 0.0011338115436956286, 3.0664407404401572e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0612.jpg\twas getekent; als vooren.; willem van Outhoorn,; w\t[0.0008010026649571955, 0.9977357387542725, 0.0014596428954973817, 3.6242556689103367e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0613.jpg\tdat over de saken van Japan aen; dese tafel wierde\t[0.0010392291005700827, 0.9963023662567139, 0.0026527675800025463, 5.5267964853555895e-06]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1490_0614.jpg\ttot uijtvindinge van een expedient,; waer door de \t[0.0001319567672908306, 0.0004154530761297792, 0.9994438290596008, 8.69086852617329e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "12batch [00:15,  1.65s/batch]                          "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1490_0615.jpg\ten ons buijten postuer te brengen,; om de dierbare\t[0.9996631145477295, 0.00025345568428747356, 5.472698467201553e-05, 2.8706832381431013e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0616.jpg\ta:o 1684. wierde geordonneert in; haere herwaerts \t[0.0012444094754755497, 0.9975848197937012, 0.0011656596325337887, 5.085044904262759e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0617.jpg\trijkelijk te konnen versorgen,; mitsgaders het mis\t[0.0007251425413414836, 0.9982725381851196, 0.000998975709080696, 3.343217713336344e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0618.jpg\tgepractiseert geworden is, sullen; moeten doen hou\t[0.0006678376812487841, 0.9983385801315308, 0.0009903855388984084, 3.1583035706717055e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0619.jpg\tover te steeken, agtervolgens; sodanige Zeijlaes o\t[0.0006566886440850794, 0.9982996582984924, 0.0010404939530417323, 3.1756430871610064e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0620.jpg\tgecarteert legt, maer dat oock de; stronien inde m\t[0.0006548099918290973, 0.9982233643531799, 0.001118555199354887, 3.1896015570964664e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0621.jpg\tde stranen sig veeltijts daer na; reguleeren van g\t[0.0006491956301033497, 0.9982098340988159, 0.0011378113413229585, 3.2301334158546524e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0622.jpg\teen weg is, nu wel eenige jaren; van japan na bata\t[0.0006489203660748899, 0.9981948733329773, 0.0011529838666319847, 3.243203082092805e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0623.jpg\tten zuijden om beoosten de eijlanden; van natuna o\t[0.0006433538510464132, 0.9981895089149475, 0.0011639344738796353, 3.2173334147955757e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0624.jpg\tnog een droogte genaemt kleijn; enckhuijser sant, \t[0.0006793365464545786, 0.9982150793075562, 0.0011023260885849595, 3.2933630791376345e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0625.jpg\tlange jaren niet voorgevallen is; dat dese coursen\t[0.0006404592422768474, 0.9981909394264221, 0.001165404450148344, 3.1857982776273275e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0626.jpg\tvan siam en Toncquin herwaerts; sullen komen, als \t[0.0006345402216538787, 0.9981821775436401, 0.0011800663778558373, 3.1648241929360665e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0627.jpg\tvan een hogre prijse als ordinair; te nootsaeken, \t[0.0006346344598568976, 0.9981833100318909, 0.001178803388029337, 3.1598758596373955e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0628.jpg\tals voren. was getekent. . ..; . . . . - Willem va\t[0.0006395544041879475, 0.998151957988739, 0.001205200795084238, 3.1904289699014043e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0629.jpg\tin eenig emploij van onsien kan; werden gebruijckt\t[0.0006873567472212017, 0.9979308843612671, 0.0013783191097900271, 3.461678034000215e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1490_0630.jpg\tvoorde schipper aende Tafel en in het; gebet, eeni\t[0.0009467980125918984, 0.9958017468452454, 0.003246003994718194, 5.453542598843342e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1490_0631.jpg\tBo0; Secrets.; wee; De bovenstaende secrete resolu\t[0.0001117201754823327, 0.0003412311489228159, 0.9995393753051758, 7.70781571191037e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "13batch [00:15,  1.31s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0110.jpg\tgemerkt &E.; Waarmeede; Edele hoog agtbaare gebied\t[0.9996683597564697, 0.00023772170243319124, 6.379025580827147e-05, 3.0142153264023364e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0111.jpg\tMinuit ola door den P„r gesaghebber ale ander wigl\t[0.0016885414952412248, 0.9953450560569763, 0.002958133118227124, 8.329462616529781e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1547_0112.jpg\tl  eene heben em maede slekt e ondergeende kopmans\t[0.00012205754319438711, 0.00031572484294883907, 0.9995546936988831, 7.4977456279157195e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "14batch [00:15,  1.00s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8820_0069.jpg\tVan Cormandel deder 24: November ao 1702.; Jck ond\t[0.9996696710586548, 0.00024816161021590233, 5.3943706006975845e-05, 2.814264917105902e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0070.jpg\tVan Cormandel onder 24: November 1702.; gevonden 6\t[0.0012739149387925863, 0.9975729584693909, 0.0011480273678898811, 5.127843905938789e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0071.jpg\tVan Cormandel onder 24: November 1702.; had geordo\t[0.0007494880701415241, 0.9982807636260986, 0.0009664397803135216, 3.3273411190748448e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0072.jpg\tVan Cormandel onder 24: November 1702:; Aen den He\t[0.0006500694435089827, 0.9983468055725098, 0.0010000088950619102, 3.0433000119955977e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0073.jpg\tVan Cormandel onder 24: November 1702.; gedoente d\t[0.0006400021375156939, 0.9983522891998291, 0.0010047731921076775, 3.0109290491964202e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0074.jpg\tVan Cormandel onder 24: November 1702.; soo sal de\t[0.0006451566005125642, 0.9983273148536682, 0.0010244193254038692, 3.0376211270777276e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0075.jpg\tVan Cormandel onder 24: November 1702.; ten dienst\t[0.0006939803133718669, 0.9981359243392944, 0.0011667419457808137, 3.3261733278777683e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8820_0076.jpg\tVan Cormandel onder 24: November 1702.; de allermi\t[0.0009801369160413742, 0.9958691000938416, 0.0031452695839107037, 5.456814960780321e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_8820_0077.jpg\tVan Cormandel onder 24: November 1702.; gevolgen, \t[0.0001225833548232913, 0.0003959170717280358, 0.9994732737541199, 8.190352673409507e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "15batch [00:16,  1.22batch/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_2682_0249.jpg\tMet het ondergenoemde schip; vertrekken over China\t[0.9980717897415161, 0.00100780522916466, 0.0007985559059306979, 0.00012173243158031255]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16batch [00:23,  2.78s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3095_0015.jpg\tRegister der Papieren; werdende versonden per het \t[0.9996663331985474, 0.00024714358733035624, 5.76371603528969e-05, 2.8874936106149107e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0016.jpg\t4.; orig: in genaagt, a:o p„o; d'Edele Groot Agtba\t[0.001223199418745935, 0.997593104839325, 0.0011785266688093543, 5.070771749160485e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0017.jpg\tN:o 7. Copia Generale Resolutien des Casteels; Bat\t[0.0007239365368150175, 0.9982640147209167, 0.0010087478440254927, 3.3508467822684906e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0018.jpg\tCommissien, Memorien,; Jnstructien en z:, welke; v\t[0.0006688731373287737, 0.9983238577842712, 0.0010040155611932278, 3.1686290640209336e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0019.jpg\tNo 14. Thien. Gesloten Pacquetten, houdende; de ad\t[0.0006571879494003952, 0.9983505010604858, 0.0009891919326037169, 3.1126539852266433e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0020.jpg\tCommissien, Memorien; Jnstructien en z:, weg; van \t[0.000654137518722564, 0.9983620047569275, 0.0009807328460738063, 3.0887349566910416e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0021.jpg\tden Raad ten evengemelde; Gouvernemente aan als; v\t[0.0006300818058662117, 0.9983458518981934, 0.0010211337357759476, 2.9517161692638183e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0022.jpg\tBengale zyn vertrokken; zynde dit paquet gelegt; i\t[0.0006266740383580327, 0.9983575940132141, 0.001012682798318565, 2.941516640930786e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0023.jpg\tGouverneur van Malacca; Mr. Thomas Schippers; als \t[0.0006260615191422403, 0.9983388185501099, 0.0010320721194148064, 2.9539201022998895e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0024.jpg\tdit berigt nog niet; ingekomen zijnde; zal bij nad\t[0.0006380101549439132, 0.9983629584312439, 0.000996013288386166, 2.9559894301200984e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0025.jpg\tN:o 22. Copia Berigt vande Administra„; teurs inde\t[0.0006246310658752918, 0.9983581900596619, 0.0010141890961676836, 2.9250443276396254e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0026.jpg\tde met verscheide scheepen; aangebragte Manufactuu\t[0.0006234394968487322, 0.9983590245246887, 0.0010145062115043402, 2.919158532677102e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0027.jpg\ten 1769. van Cochim overge; sonden, waarbij densel\t[0.0006224109674803913, 0.9983538389205933, 0.0010209041647613049, 2.9081786578899482e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0028.jpg\tN:o 28 Drie Copia Berigten van eevengem:; E: Honti\t[0.0006207165424712002, 0.9983552098274231, 0.0010211959015578032, 2.9008285764575703e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0029.jpg\tN:o 30 Copia Request door den advocaat M:r Jacob; \t[0.0006263265968300402, 0.9983614087104797, 0.0010093736927956343, 2.9127859306754544e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0030.jpg\tsComp:s wapenkamer Reisich; en Expresse gecommitte\t[0.000619604776147753, 0.9983559250831604, 0.0010215521324425936, 2.9019347493886016e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0031.jpg\tN:o 35. Een Exomplaar van het Generaal Re„; 1 glem\t[0.0006216022884473205, 0.9983589053153992, 0.0010166752617806196, 2.9052880563540384e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0032.jpg\tN:o 38. Tes origineele; Actens van Indem; & niteil\t[0.0006200880161486566, 0.9983568787574768, 0.0010201653931289911, 2.9012344384682365e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0033.jpg\tN:o 40. Vier Turksche Passen vande afgelegde en; v\t[0.0006214953027665615, 0.998354971408844, 0.0010206407168880105, 2.905681412812555e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0034.jpg\tGeneraalen Eisch van behoeftens uijt; No 44; Neder\t[0.0006247332785278559, 0.9983287453651428, 0.0010435209842398763, 2.935535349024576e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0035.jpg\tN:o 49 Generaal Rendement vande verkogte; 1 onbesc\t[0.0006622809451073408, 0.9981604218482971, 0.001174126984551549, 3.159577545375214e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3095_0036.jpg\tN: 53. Maandelyksche Restanten inde; groote geldka\t[0.0008991407230496407, 0.9968094229698181, 0.0022863915655761957, 5.0018397814710625e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_3095_0037.jpg\tN:o 57: Sommarium van het geladene in tien; Retoúr\t[0.0001341540482826531, 0.0004345295892562717, 0.999422550201416, 8.789587809587829e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "17batch [00:24,  2.23s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8260_0061.jpg\tS morgens te agt uuren nog geen bevoeging in het B\t[0.9996588230133057, 0.0002552396326791495, 5.6450662668794394e-05, 2.949877489299979e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0062.jpg\tinsgelijks een bentings op te werepan, waarop ik h\t[0.0012324214912950993, 0.9976182579994202, 0.0011441261740401387, 5.056373993284069e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0063.jpg\tgeschied zynde, goa zig 's morgens te negen uuren \t[0.0007091356092132628, 0.9982755184173584, 0.0010121166706085205, 3.2632633519824594e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0064.jpg\tverlies van onsekant Heer op mij wederom met den p\t[0.0006529196980409324, 0.9983458518981934, 0.0009981091134250164, 3.0607200187660055e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0065.jpg\tIk gaf dierhalven den provisconelen vandrig sor sc\t[0.0006436578114517033, 0.998359739780426, 0.0009936420246958733, 3.0210069326130906e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0066.jpg\tvan goa lag, zullende zyn volk zuyd wertwaarts vuu\t[0.0006423511076718569, 0.9983603358268738, 0.0009943749755620956, 3.0264532142609823e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0067.jpg\tpligt gadesloeg, ende ordres stijtelijk op gevolgd\t[0.0006398091209121048, 0.9982814788818359, 0.0010757429990917444, 2.927981540779001e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0068.jpg\teyndelijk de banting ook verlaten waar door wij da\t[0.0006296708597801626, 0.9983571171760559, 0.0010101791704073548, 2.9558877940871753e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0069.jpg\tvagd: den 31 octob 1757; Zatuad„ 1 Nov: 1777; Maan\t[0.0006317142397165298, 0.998335063457489, 0.0010302405571565032, 2.9675154564756667e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0070.jpg\thadden met vorsheid en onder de bedreiging gevraag\t[0.0006252776365727186, 0.9982781410217285, 0.0010936630424112082, 3.009861302416539e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0071.jpg\tDe Heere gouverneur goedgevonden hebbende den post\t[0.0006344968569464982, 0.9983128309249878, 0.0010497220791876316, 2.981579200422857e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0072.jpg\tneur addaes seeren moest; vryd. den 21 Noo 1oor De\t[0.0006755624199286103, 0.9981073141098022, 0.001213898416608572, 3.181742386004771e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0073.jpg\tden ged den 2: Aor 1757; rijst navens een Jnlandse\t[0.0008250745013356209, 0.9974762797355652, 0.0016947472468018532, 3.909864062734414e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8260_0074.jpg\teenige maanden neets anders te hebben gedaan als k\t[0.0011982565047219396, 0.9945869445800781, 0.00420792493969202, 6.928751645318698e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_8260_0075.jpg\tAan den Lieutenant militair Alexander LeCerf; Comm\t[0.00011157513654325157, 0.0003471864911261946, 0.9995335340499878, 7.767402166791726e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "18batch [00:25,  1.87s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_3248_0877.jpg\tOp Huijden den 5: October a„o 1761: voor mij Wolfe\t[0.9996320009231567, 0.0002867208095267415, 4.938192796544172e-05, 3.196508623659611e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0878.jpg\top die wijze gedurende hun verblijf aldaar, en ond\t[0.001041713054291904, 0.9980586171150208, 0.0008950007613748312, 4.679641733673634e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0879.jpg\tniet krijgende ! de Xullas aandoen, en overweldige\t[0.0006033992394804955, 0.9986262321472168, 0.0007672395440749824, 3.0666906241094694e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0880.jpg\tvan Christoffel dias, en Adriaan Rijkschroef clerc\t[0.0005511748022399843, 0.998690664768219, 0.0007553162868134677, 2.8560384635056835e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0881.jpg\tHeden den 8:e Maart 1762: Compareerde voor mij Ioh\t[0.0005697144661098719, 0.9987142086029053, 0.0007132465834729373, 2.879525027310592e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0882.jpg\tdog Een van derzelver prauwen bleeft op de droogte\t[0.0005534894298762083, 0.998711347579956, 0.0007322736782953143, 2.8159558951301733e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0883.jpg\teenige hostiliteijten en moorderijen gepleegt hadd\t[0.0005315798334777355, 0.9986990690231323, 0.0007666207966394722, 2.751178499238449e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0884.jpg\twaar op hij relatant door de papoeers, mits absent\t[0.0005253515555523336, 0.9987032413482666, 0.0007686518947593868, 2.715064510994125e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0885.jpg\tanders te zeggen, als 't geen in 't Casteel orange\t[0.0005246676737442613, 0.9986818432807922, 0.0007907043327577412, 2.6881239136855584e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0886.jpg\thij relatant in dien zoo wel onder Ambon als Terna\t[0.0005455595091916621, 0.9986900687217712, 0.0007616047514602542, 2.7401929401094094e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0887.jpg\tGevende voor redenen van wetenschap als in den tex\t[0.0005269972607493401, 0.9985861778259277, 0.0008841806557029486, 2.5771616947167786e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0888.jpg\t\t[0.0004617199010681361, 0.99873286485672, 0.00080327526666224, 2.091157512040809e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0889.jpg\tHeden morgen den 23:e April 1765: zont den heer„; \t[0.0004745962214656174, 0.998802900314331, 0.0007198433158919215, 2.6311706733395113e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0890.jpg\ten 's konings goetaardigheijt, de wezentlijke oerz\t[0.00046428231871686876, 0.9988126754760742, 0.0007204760331660509, 2.6017896743724123e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0891.jpg\tomtrent zij vermeenden nu niets meer te vreezen te\t[0.0004948658170178533, 0.9985785484313965, 0.0009241001098416746, 2.4571056655986467e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0892.jpg\t\t[0.00031867981306277215, 0.9991738200187683, 0.0005054727080278099, 1.9789638372458285e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0893.jpg\tHeden den 4:e Februarij 1768: Compareerde; voor mi\t[0.0004300725122448057, 0.9987701773643494, 0.000797189655713737, 2.5076935799006606e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0894.jpg\tgelegen op 't groot Eijland salwattij vervoert en \t[0.0004951527807861567, 0.9981460571289062, 0.0013563052052631974, 2.5523279418848688e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0895.jpg\t\t[0.00019082750077359378, 0.9993895292282104, 0.00041762084583751857, 2.0116340238018893e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0896.jpg\t\t[0.00017521920381113887, 0.9995705485343933, 0.0002525212476029992, 1.6441463230876252e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0897.jpg\tOp heden den 4:e Februarij 160: Compareerde voor; \t[0.0004479634517338127, 0.9987395405769348, 0.0008095962693914771, 2.9945965707156574e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0898.jpg\tte Batchian ter hou gekomen waren, en zig dien twe\t[0.0004694670205935836, 0.9987322688102722, 0.0007951332372613251, 3.0624830742453923e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0899.jpg\tWaar mede den relatant dit zijne gegevene relaas c\t[0.000499177083838731, 0.9984733462333679, 0.0010242389980703592, 3.1782651603862178e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0900.jpg\t\t[0.00047722746967338026, 0.997931718826294, 0.0015879261773079634, 3.0549574603355723e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_3248_0901.jpg\tOp heden den 8:e Februarij 1768: Compa„; „reerde v\t[0.0007398593006655574, 0.9967026114463806, 0.002552059479057789, 5.509052698471351e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_3248_0902.jpg\twaar mede den relatant zijn gegevene relaas quam t\t[0.00011051086039515212, 0.00041598553070798516, 0.9994648098945618, 8.639186489745043e-06]\n",
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0107.jpg\tExtracten uijt de Daagelijkse Aanteeckeningen, Con\t[0.9996719360351562, 0.00018414098303765059, 0.00010387448855908588, 4.000259650638327e-05]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1547_0108.jpg\top desen holvn en dass: matthijs in ve totenende a\t[0.0002052070340141654, 0.0003014642861671746, 0.9994825124740601, 1.080017591448268e-05]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "21batch [00:26,  1.09batch/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0360.jpg\t\t[4.6434310206677765e-05, 2.5492503482382745e-05, 1.813627386582084e-05, 0.9999098777770996]\n",
-      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0361.jpg\t\t[1.5475776308448985e-05, 8.291252925118897e-06, 6.33479203315801e-06, 0.9999698400497437]\n",
-      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0362.jpg\t\t[2.7481732104206458e-05, 1.5985984646249563e-05, 1.1455773346824571e-05, 0.9999450445175171]\n",
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0363.jpg\tJnstructie voor den onder„; Sonsbeek, vertreckende\t[0.9995558857917786, 0.00018646824173629284, 3.85285857191775e-05, 0.00021914199169259518]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0364.jpg\top te wakkeren sijn, soo meede te Ervaaren wat; Ef\t[0.002504652366042137, 0.9966664910316467, 0.0007734567625448108, 5.537641845876351e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0365.jpg\tVan ons gering vermoogen, voort te setten onder an\t[0.0008247647783719003, 0.9984316229820251, 0.0007315014954656363, 1.215212614624761e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0366.jpg\taanslaagen der picaten en roovers, en des noods; s\t[0.0005118739209137857, 0.9987766146659851, 0.0007074211025610566, 4.018368144897977e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0367.jpg\tgesant Pannejapaija gemaakt, sijn afgehaald; dan g\t[0.00045651374966837466, 0.9988409876823425, 0.0006995375733822584, 3.011161879840074e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0368.jpg\ten hem aanbeveelt om ten uijterken mogelijk den ge\t[0.00044906220864504576, 0.9988435506820679, 0.0007044600206427276, 2.8988090434722835e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0369.jpg\tdat sijne regenten een slankxe parthonen; te speel\t[0.0004513795138336718, 0.9988102912902832, 0.0007353551918640733, 2.9356237973843236e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0370.jpg\tIagthens de Jaager en plathuijs zullen connen; lad\t[0.00046287011355161667, 0.9986509680747986, 0.0008831138256937265, 3.122991074633319e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1547_0371.jpg\td'E Comp=es mogte te verrigten wesen, maar; de wij\t[0.0006486622733063996, 0.9967778325080872, 0.002568044001236558, 5.455006430565845e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1547_0372.jpg\taanbevoolen, en uwE: onder godes geleyjd een; spoe\t[0.00010998263314832002, 0.0004691403592005372, 0.9994113445281982, 9.502371540293097e-06]\n",
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8846_0473.jpg\tVan Cormandel onder dato 27:e 8ber: 1726.; Nederla\t[0.9996780157089233, 0.0002323529333807528, 6.03265616518911e-05, 2.930586379079614e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8846_0474.jpg\tVan Cormandel onder dato 27=e 8ber: 1726.; der inl\t[0.0017240848392248154, 0.9953752160072327, 0.002892346354201436, 8.376827281608712e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_8846_0475.jpg\tVan Cormandel onder dato 27=e 8ber: 1726.; Agtbaar\t[0.00012310445890761912, 0.00031795402173884213, 0.9995513558387756, 7.550971076852875e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "23batch [00:29,  1.13s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1083_0013.jpg\tadn. 6=en augustij Anoo 1624; Octe der kerckelijck\t[0.999489426612854, 0.00037690700264647603, 8.722964412299916e-05, 4.6380584535654634e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0014.jpg\t\t[0.006468998268246651, 0.9929623007774353, 0.0003682940441649407, 0.0002003989793593064]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0015.jpg\tInt Jaer des Heeren onses Salichmaeckers Jesu Chri\t[0.002301795408129692, 0.996840238571167, 0.0008491344633512199, 8.752758731134236e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0016.jpg\tKercken dienaers soo te lande als opde; Rhede alhi\t[0.0005745316157117486, 0.9986787438392639, 0.0007434916333295405, 3.1757979286339832e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0017.jpg\tVerlost moeten werden midtsgaders offf oock eenige\t[0.0005185448681004345, 0.9987021684646606, 0.0007762503810226917, 2.94998312710959e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0018.jpg\tAlsoo de Generale Comp. e. dageluckx boven haer ve\t[0.0005135959945619106, 0.9986936450004578, 0.0007897705072537065, 2.926774868683424e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0019.jpg\tAdvijs vande Kerckelijcke vergaderinge (door orden\t[0.0005006034625694156, 0.998701810836792, 0.0007947087869979441, 2.837919964804314e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0020.jpg\tArt 1; Om goede ordre inde gemeente Christij te on\t[0.000499618356116116, 0.9987049102783203, 0.0007926252437755466, 2.830986886692699e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0021.jpg\tHantwercx lieden ofte andere die niet gestudeert h\t[0.0004995114868506789, 0.9987039566040039, 0.0007936035981401801, 2.829575123541872e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0022.jpg\tVertrecken ofte andersins eenige veranderingen van\t[0.0004985055420547724, 0.9987051486968994, 0.0007934898603707552, 2.8246315650903853e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0023.jpg\ttot een meerder kerckelicke vergaderinghe vereepen\t[0.0005042327102273703, 0.9987081289291382, 0.0007847902015782893, 2.8356409984553466e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0024.jpg\tArmen scholen besorcht werden ten laesten offer; y\t[0.0004974631010554731, 0.9987051486968994, 0.0007945378310978413, 2.8187973839521874e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0025.jpg\tals de beyaerde persoonen de formeliere vande Inst\t[0.0004998924559913576, 0.9987020492553711, 0.0007952404557727277, 2.8236072466825135e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0026.jpg\tDe dienaers sullen alomme soo veel alsmogelyck is \t[0.0004965164698660374, 0.9987039566040039, 0.0007966588018462062, 2.8116924113419373e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0027.jpg\tsoo wie hartneckelijcke de vermaninge des kercken;\t[0.0004965902771800756, 0.9986995458602905, 0.0008010820602066815, 2.79268761005369e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0028.jpg\traets der selver ende der naestgelegener gemeente \t[0.000490343663841486, 0.9987045526504517, 0.0008023062837310135, 2.765329782050685e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0029.jpg\tEenige poincten de welcke de kerckelijcke; vergade\t[0.00048802929813973606, 0.9987095594406128, 0.0007996756467036903, 2.742923470577807e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0030.jpg\tSimode gehouden tot dordrecht sess 19. dit sul; in\t[0.0005082749994471669, 0.9987139701843262, 0.0007748546195216477, 2.8119002308812924e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0031.jpg\tgevisiteert de plaetse tot opbouwinge der kercken \t[0.0004902033833786845, 0.9987026453018188, 0.0008044058922678232, 2.7678759124682983e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0032.jpg\thouden des H: Avondtmaels ende telckens tusschen d\t[0.0004924112581647933, 0.9987032413482666, 0.0008015438797883689, 2.771329718598281e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0033.jpg\tdaer naer met den volcke singht oit wert den kerck\t[0.0004889032570645213, 0.9986991882324219, 0.0008091583731584251, 2.74801891464449e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0034.jpg\tWaer dient een retutatie des Moorsdoms ofte mahune\t[0.00048767434782348573, 0.9987004995346069, 0.0008090248447842896, 2.7543642318050843e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0035.jpg\tnaecome volgens de order en vande kercken beraempt\t[0.00048454091302119195, 0.9987013339996338, 0.000811391044408083, 2.73178011411801e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0036.jpg\tmoeten opseggen; de Schoolmr. moet sorge dragen da\t[0.00048317291657440364, 0.9987021684646606, 0.0008119366830214858, 2.7236351343162823e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0037.jpg\tatechismum met sin aenhanghar ondr. Sebast: danck \t[0.0004839519679080695, 0.9987010955810547, 0.0008121808641590178, 2.7275518732494675e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0038.jpg\tAlle de Gene die tot noch toe geseten hebben ende \t[0.0004827906668651849, 0.9987027645111084, 0.0008117486140690744, 2.7222135940974113e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0039.jpg\tleeren lesen schrijven ende in Christelycke deuchd\t[0.0004841367481276393, 0.998699426651001, 0.0008137177210301161, 2.725838839978678e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0040.jpg\tgelegentheyt der plaetsen door de welcke de andere\t[0.0004895331803709269, 0.9986829161643982, 0.0008247890509665012, 2.7491826131154085e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0041.jpg\tCorte, bedenckinge op eenige verhandelde; poincten\t[0.0005203329492360353, 0.9985746145248413, 0.0009021282312460244, 2.8756567189702764e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0042.jpg\tWert verstaen de bedieninge vant Sacrament des H; \t[0.000623463885858655, 0.9982129335403442, 0.0011601283913478255, 3.3944261303986423e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0043.jpg\tbijde Gecommitteerde wegen de Zinodale Classe; van\t[0.0008165809558704495, 0.9970476031303406, 0.0021305617410689592, 5.17204853167641e-06]\n",
-      "END\tIN\tNL-HaNA_1.04.02_1083_0044.jpg\tOp Appendicx vande kercken ordeninge ten aensien d\t[0.0001296506088692695, 0.0005003982805646956, 0.9993603825569153, 9.660720024839975e-06]\n",
-      "BEGIN\tIN\tNL-HaNA_1.04.02_1083_0045.jpg\tInt laeste vandese Schiftelijcke voorstellinge; so\t[0.9996755123138428, 0.00024183573259506375, 5.48631142009981e-05, 2.7853617211803794e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0046.jpg\tEd: Hr Generael vallende soo is Octob. 23 de ver; \t[0.0013425718061625957, 0.9972915053367615, 0.0013602792751044035, 5.607696493825642e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_1083_0047.jpg\tJustus Hurnius, O Sebastianus danckaerts door siec\t[0.001119152526371181, 0.9960830211639404, 0.002791952108964324, 5.809199137729593e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_1083_0048.jpg\tDes avondts voor het aronsteten is den predicanten\t[0.00011469714809209108, 0.0002957984106615186, 0.9995825886726379, 6.894711077620741e-06]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "24batch [00:30,  1.29s/batch]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8696_0051.jpg\tVan Siam onder dato 20: april 1737; Dag-register, \t[0.999670147895813, 0.0002444376586936414, 5.7068929891102016e-05, 2.8394919354468584e-05]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0052.jpg\tVan Siam onder dato 20:' april 1731; moesten verbl\t[0.0013370545348152518, 0.9975607395172119, 0.0010970152216032147, 5.258822511677863e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0053.jpg\tVan Siam onder dato 20: april 1737; zijn aen gesig\t[0.0007060010102577507, 0.9982632994651794, 0.0010274903615936637, 3.2366833693231456e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0054.jpg\tSiam onder dato 2 april 1737; den 8:e _=o alvroeg \t[0.0006481486489064991, 0.9983488321304321, 0.0010000128531828523, 3.0164023883116897e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0055.jpg\tVan Siam onder dato: 20: april 1737; ons aengewees\t[0.0006393356015905738, 0.9983567595481873, 0.0010009024990722537, 3.0001624509168323e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0056.jpg\tVan Siam onder dato: 20: april 1737; Maart; die ge\t[0.000636874872725457, 0.9983591437339783, 0.0010010089026764035, 2.9910390821896726e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0057.jpg\tVan Siam onder dato 20: april 1737; vergadert was \t[0.0006361103733070195, 0.9983586668968201, 0.0010022283531725407, 2.9903987979196245e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0058.jpg\tVan Siam onder dato: 20: april 1737; Maart voogd v\t[0.0006340733380056918, 0.9983593821525574, 0.001003555953502655, 2.9765162707917625e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0059.jpg\tVan Siam onder dato: 20: april 1737; houden dit go\t[0.0006316512590274215, 0.9983568787574768, 0.0010085266549140215, 2.960318852274213e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0060.jpg\tSiam onder dato: 20: april 1737; an; kittelde en h\t[0.0006313940975815058, 0.9983612895011902, 0.0010042975191026926, 2.9419848033285234e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0061.jpg\tVan Siam onder dato: 20:' april 1737; Excuseert, m\t[0.0006212075240910053, 0.9983558058738708, 0.001020123832859099, 2.905534074670868e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0062.jpg\tan Siam onder dato: 20: april 1737; kittelde en he\t[0.0006206798716448247, 0.9983577132225037, 0.0010187646839767694, 2.9037501008133404e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0063.jpg\tVan Siam onder dato: 20=' april 1737; Excuseert, m\t[0.000621096754912287, 0.9983554482460022, 0.0010206052102148533, 2.9039154014753876e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0064.jpg\tSiam onder dato: 20: april 1737; opperhoofd een ro\t[0.0006202600779943168, 0.998357355594635, 0.0010195111390203238, 2.9013215225859312e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0065.jpg\tVan Siam onder dato 20: april 1737; op thee en Con\t[0.0006205941317602992, 0.9983564019203186, 0.0010200762189924717, 2.9026832635281608e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0066.jpg\tSiam onder dato: 20: april 1737; -; Aan; Maart; te\t[0.0006209531566128135, 0.9983554482460022, 0.0010207360610365868, 2.9002260362176457e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0067.jpg\tSiam onder dato: 20: april 1737; N6; an alderhande\t[0.0006203092634677887, 0.9983568787574768, 0.0010199133539572358, 2.9018706300121266e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0068.jpg\tSiam onder dato: 20: apr; an; telaeten zien met we\t[0.0006232424639165401, 0.9983499050140381, 0.0010239380644634366, 2.9159541554690804e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0069.jpg\tVan Siam onder dato: 29:' april 1737; koraelen van\t[0.000619316182564944, 0.9983554482460022, 0.0010223675053566694, 2.89698346023215e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0070.jpg\tVan Siam onder dato: 20: april 1737; den 16:e d:o \t[0.0006296892534010112, 0.9983629584312439, 0.0010043432703241706, 2.919083726737881e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0071.jpg\tVan Siam onder dato: 20: april 1737; middelpunt te\t[0.0006444074679166079, 0.9983673691749573, 0.000985319260507822, 2.942080982393236e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0072.jpg\tan Siam onder dato: 20: april 1737; Elders wierd g\t[0.0006191381835378706, 0.9983527660369873, 0.0010252174688503146, 2.895453917517443e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0073.jpg\tVan Siam onder dato: 20: april 1737; te hebben ons\t[0.0006266593700274825, 0.9983281493186951, 0.001042242394760251, 2.9253412776597543e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0074.jpg\tSiam onder dato: 20: april 1737; An; 99; Elders wi\t[0.000664147490169853, 0.998204231262207, 0.0011285552754998207, 3.0738140139874304e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0075.jpg\tVan Siam onder dato: 20: april 1737; te hebben ons\t[0.0008026157156564295, 0.9976639747619629, 0.0015297934878617525, 3.7259728742355946e-06]\n",
-      "IN\tIN\tNL-HaNA_1.04.02_8696_0076.jpg\tVan Siam onder dato: 20: april 1737; van hof order\t[0.001106353709474206, 0.9949514865875244, 0.003935439046472311, 6.783654498576652e-06]\n",
-      "END\tEND\tNL-HaNA_1.04.02_8696_0077.jpg\tVan Siam onder dato: 20: april 1737; Translaet Sia\t[0.00011269961396465078, 0.00034607292036525905, 0.9995334148406982, 7.784056833770592e-06]\n"
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1108_0653.jpg\td' E. d: heeren Bewindehebberen; mpult. febr. 1633\t[0.9999197721481323, 6.24519307166338e-05, 1.5677125702495687e-05, 1.9859278381773038e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0654.jpg\tsyn gecompareert, die terstont liet vast binden, e\t[0.0010502388468012214, 0.9982824325561523, 0.0005819913931190968, 8.536814129911363e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0655.jpg\t3a di dito smorgens sagen seecker vaertuyg onder't\t[0.00026778728351928294, 0.9994713664054871, 0.0002345546381548047, 2.6388303012936376e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0656.jpg\tvoor de Manipo, vandewelcke voor desen geschreven \t[0.00020679035515058786, 0.9994906187057495, 0.0002777914342004806, 2.475599649187643e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0657.jpg\ttegenwoordigh inde Negrij geen nagelen waren: dien\t[0.0001687015756033361, 0.9995935559272766, 0.00021830877813044935, 1.936741500685457e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0658.jpg\tdie haer aenhouden, te straffen, so veel als in on\t[0.00016586948186159134, 0.9995930790901184, 0.00021907805057708174, 2.209253034379799e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0659.jpg\t2 a 3 Portugeesche 23 haar nagelen hadden, doch de\t[0.00017260017921216786, 0.9995937943458557, 0.0002146018814528361, 1.9025776055059396e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0660.jpg\tTerstont soud d' H. r Gouvr beyde sloupen, d'een a\t[0.0001603497948963195, 0.9996011853218079, 0.0002184045733883977, 2.0086043150513433e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0661.jpg\td' E.d: heeren Bewindthebberen; van Iustitia gehoo\t[0.00015919358702376485, 0.99960857629776, 0.00021341028332244605, 1.8863815057557076e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0662.jpg\tVruchtbomen, te weten Ionge clappus, pinang als an\t[0.00016156421042978764, 0.9996005892753601, 0.00021904772438574582, 1.8769489543046802e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0663.jpg\tdoor de ruychte vant strand te gaen: ('t pad voor \t[0.00016394078556913882, 0.9995911717414856, 0.00022467879171017557, 2.031563053606078e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0664.jpg\tmede op 't strand by d'Inwoonders van kelang getre\t[0.0001676643150858581, 0.9995982050895691, 0.0002132056833943352, 2.101791324093938e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0665.jpg\tNde 9 dito smorgens heeft syn Ed. de twee gevangen\t[0.00015051313675940037, 0.9996254444122314, 0.00020499889797065407, 1.912260995595716e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0666.jpg\tinformatie te nemen wegens de saaken vanden Vaendr\t[0.00016821149620227516, 0.9995843768119812, 0.00022899899340700358, 1.8499513316783123e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0667.jpg\tdEenwinne, om de stucken ten lasten vanden Vaendri\t[0.0001535515475552529, 0.9996175765991211, 0.00020974902145098895, 1.91108829312725e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0668.jpg\tCambello op Lissien te houden, en daer door d'inwo\t[0.00016252828936558217, 0.9995896220207214, 0.0002276831364724785, 2.0098648747080006e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0669.jpg\tsyn noch twee gelycke sterckten gepasseert: Eyndlj\t[0.00015412223001476377, 0.9996250867843628, 0.00020375513122417033, 1.6988362403935753e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0670.jpg\tdat 't schijnt de Magellaense Vloot haer devoir op\t[0.00015536257706116885, 0.9996144771575928, 0.0002116833347827196, 1.848770807555411e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0671.jpg\tbeneden monsteren, ende bevonden de soldaten 48 co\t[0.00019786959455814213, 0.9995360374450684, 0.0002472983323968947, 1.8807104424922727e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0672.jpg\tJoncq) diep inde Livier opgehaelt: deden deselve e\t[0.00016139472427312285, 0.9996143579483032, 0.00020596978720277548, 1.8246562831336632e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0673.jpg\tdie gansch te raseeren: doch weynich daer nae quam\t[0.00015243333473335952, 0.9996194839477539, 0.00020893027249258012, 1.9198272639187053e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0674.jpg\tSyn Ed. heeft eenige der Principaelste Orangquais \t[0.000153871180373244, 0.9996160268783569, 0.0002124096645275131, 1.7658339857007377e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0675.jpg\tschilden ende omhieuwen, alwaer met een bas cogel \t[0.00017488155572209507, 0.9996033310890198, 0.00020091229816898704, 2.0908704755129293e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0676.jpg\tVarend Volck met wel gemonteerde Jachten, dewelcke\t[0.0001687192707322538, 0.9995983242988586, 0.00021438764815684408, 1.8620237824507058e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0677.jpg\tvan Justitia gehoort ende geexamineert is Joncker \t[0.00017410989676136523, 0.9995947480201721, 0.00021057155390735716, 2.058024620055221e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0678.jpg\td'Armade, en 't Jacht Ceylon met timmerhout voor B\t[0.0001671028439886868, 0.9996054768562317, 0.00020776617748197168, 1.962031274160836e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0679.jpg\tVoor Cambelle comen is de corrocor van Loemecaij d\t[0.00016558411880396307, 0.9996059536933899, 0.0002102290018228814, 1.828431231842842e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0680.jpg\tbeyjde sijden vande Logie een corps da guarde soud\t[0.00016501812206115574, 0.9996065497398376, 0.00020877819042652845, 1.9693779904628173e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0681.jpg\tGouv. heeft onse Corrocorren genomen, en d' Negrij\t[0.0001590132451383397, 0.999610960483551, 0.00021110419766046107, 1.8976288629346527e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0682.jpg\tNdi 4 dito: den nur voor dagh quam de slonp aen bo\t[0.00017169037892017514, 0.9995988011360168, 0.00020976367522962391, 1.9756456822506152e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0683.jpg\tTorrocor vast, doch quamen sond schade daer weder \t[0.00015455696848221123, 0.99960857629776, 0.00021754016052000225, 1.925859396578744e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0684.jpg\tVersoeckende eenige sloupen om de soldaten vande s\t[0.00014885156997479498, 0.9995892643928528, 0.00024099597067106515, 2.0807816326851025e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0685.jpg\tAdy 16 dito. naermiddags omtrent 5 uyren arriveerd\t[0.00014760873455088586, 0.9996151924133301, 0.00021841573470737785, 1.8704382455325685e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0686.jpg\tDes voormiddaghs ongevaer 10 uyren met onse Vlote \t[0.00015202187933027744, 0.9996422529220581, 0.00018677998741623014, 1.890154817374423e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0687.jpg\tPersonen ongemolesteert in vrede wederom souden se\t[0.000163794873515144, 0.9996180534362793, 0.00019866110233124346, 1.9414770576986484e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0688.jpg\taldus met ons volck beset hebbende, is by haer Ed.\t[0.00016150370356626809, 0.9996304512023926, 0.00018883282609749585, 1.9223693016101606e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0689.jpg\tende dat hare meeste macht op Killibya, Kelebrot e\t[0.00014618902059737593, 0.9996227025985718, 0.0002125016471836716, 1.864827390818391e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0690.jpg\tsel gesecondeert op den Vyant doortchergeeren der \t[0.0001581885589985177, 0.9995972514152527, 0.00022547223488800228, 1.905331555462908e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0691.jpg\tCorrocorre sijn geraackt, bequamen een gequeste, w\t[0.00014775821182411164, 0.9996354579925537, 0.00019896413141395897, 1.777709803718608e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0692.jpg\ttot welcken eynde oock van onse sterckte boven op \t[0.00013524592213798314, 0.9996216297149658, 0.00022539131168741733, 1.780712409527041e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0693.jpg\tden selven sijn vrydom belovende, soo sich hier vr\t[0.00017384710372425616, 0.9996053576469421, 0.00020255376875866205, 1.826558400352951e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0694.jpg\tDe sloupen, en 'tcleen vaertuygh inde Baij onder d\t[0.00015171989798545837, 0.9996259212493896, 0.0002045853470917791, 1.7735728761181235e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0695.jpg\tGemelte personen met d'Inwoonders gesproocken hebb\t[0.00017367520194966346, 0.9995734095573425, 0.000235046842135489, 1.7880574887385592e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0696.jpg\tvoor haer stercte gecomen waren, al voren besloote\t[0.0001497676712460816, 0.9996261596679688, 0.00020374756422825158, 2.0264445993234403e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0697.jpg\tspits afmoeten byten, en niet buyten haer geledere\t[0.0001726875634631142, 0.999599277973175, 0.0002086325694108382, 1.9479370166664012e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0698.jpg\tBij S. r. Hulft missive wert syn Ed. geadviseert, \t[0.0001600838586455211, 0.999624490737915, 0.00019655059440992773, 1.8833216017810628e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0699.jpg\tde Bas, die 't volck van't Jacht Contchin, als met\t[0.00014638472930528224, 0.9995757937431335, 0.0002593678655102849, 1.850644730438944e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0700.jpg\tpasseren, twelck nu vol rudsen en clippen van Extr\t[0.00013678777031600475, 0.9996496438980103, 0.00019632474868558347, 1.7313184798695147e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0701.jpg\tVerstonden vande Vaendrich Jonge dan, dat met sijn\t[0.00014142443251330405, 0.999626874923706, 0.00021336638019420207, 1.829186294344254e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0702.jpg\tondersaten schuldigh syn, te quijten. Dienvolgende\t[0.00015373615315183997, 0.9996060729026794, 0.00022130490106064826, 1.8887314581661485e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0703.jpg\tover te leveren, sulcx gedaen synde, als dan syn r\t[0.0001361022295895964, 0.9996541738510132, 0.00019238024833612144, 1.737310412863735e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0704.jpg\tbij sijn Ed. Corrocor gehouden had, die sulcx, Exc\t[0.00013633724302053452, 0.9995816349983215, 0.00026283273473381996, 1.9147117200191133e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0705.jpg\tdoor des kumelahas volck /s meestert waren, waer v\t[0.00022723582515027374, 0.998687207698822, 0.0010594850173220038, 2.603486973384861e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0706.jpg\t\t[0.0007644639699719846, 0.9953462481498718, 0.0035335058346390724, 0.00035568937892094254]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0707.jpg\td'EEd: heeren Bewindehebberen; Niet tegenstaende b\t[0.00023800179769750684, 0.9994907379150391, 0.0002452445914968848, 2.60237338807201e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0708.jpg\tvertrecken: 3½ maent Victualie voort' ' acht de so\t[0.0001926047698361799, 0.9995837807655334, 0.00020077296358067542, 2.288790710736066e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0709.jpg\tveele met pack en sack vluchten, end syn alsoo tot\t[0.00016357963613700122, 0.9996116757392883, 0.0002040584513451904, 2.068924186460208e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0710.jpg\tGelaly met een champan, dewelcke aldaer met volck \t[0.0001662360446061939, 0.9995918869972229, 0.0002228038210887462, 1.9034723663935438e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0711.jpg\tVan Loehoe overgelopen, die alhier eenige tyt gele\t[0.00019051588606089354, 0.9995309114456177, 0.00025710364570841193, 2.1389787434600294e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0712.jpg\tnagelbomen stont, het welck syn Ed. , en veel met \t[0.00017273754929192364, 0.9995711445808411, 0.00023593317018821836, 2.0140298147452995e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0713.jpg\tbomen beplant gevonden te hebben, dat men qual. tu\t[0.00017387245316058397, 0.9995651841163635, 0.00023991675698198378, 2.1010508135077544e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0714.jpg\tvertoonden haer boven op 't gebercht, ende sagen v\t[0.00016887013043742627, 0.9994850158691406, 0.00032474170438945293, 2.127632251358591e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1108_0715.jpg\tVande negrie: Terstont hebben alle de clappus bome\t[0.0003021344600711018, 0.995441198348999, 0.004208658821880817, 4.793847620021552e-05]\n",
+      "END\tIN\tNL-HaNA_1.04.02_1108_0716.jpg\tverstaande, dat Cerelant afgelopen, ende so menich\t[3.730009120772593e-05, 0.000179322058102116, 0.9997801184654236, 3.306605094621773e-06]\n",
+      "BEGIN\tEND\tNL-HaNA_1.04.02_1108_0717.jpg\tvoortpangayen, end syn met de corrocorren, Namentl\t[0.9998884201049805, 1.868724029918667e-05, 8.831459126668051e-05, 4.568390522763366e-06]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_8526_0329.jpg\tSumatras West cust onder dato 6„' Jan: 1723.; Jan;\t[0.9999042749404907, 7.282821752596647e-05, 2.027862865361385e-05, 2.607722763059428e-06]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0330.jpg\tVan Sumatras West uust onder dato 6:' jan: 1733.; \t[0.0010157683864235878, 0.9984830021858215, 0.0004256950051058084, 7.562986138509586e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0331.jpg\tO; Jan; Sumatras West cust onder dato 6„' Janu: 17\t[0.0002640268357936293, 0.999460756778717, 0.00025019122404046357, 2.50650573434541e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0332.jpg\tVan Sumatras Westcust onder dato 6„' Janu: 1733.; \t[0.00019925349624827504, 0.999548614025116, 0.00023040457745082676, 2.1660251150024123e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0333.jpg\tSumatras West Cust onder dato 6„' Janu: 1733.; Van\t[0.00018925036420114338, 0.9995390176773071, 0.00024866408784873784, 2.310718446096871e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0334.jpg\tVan Sumatras West Cust onder dato 6„' Janu: 1733.;\t[0.00016992616292554885, 0.999599277973175, 0.00021184895012993366, 1.8928676581708714e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0335.jpg\tVan Sumatras Westcust onder dato 6„e Janu: 173.; B\t[0.00019596780475694686, 0.9995531439781189, 0.000231225581956096, 1.9694267393788323e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0336.jpg\t&; Sumatras West Cust onder dato 6„' Janu: 1733; V\t[0.00021453933732118458, 0.9995284080505371, 0.0002343147061765194, 2.2808222638559528e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0337.jpg\tSumatras West Cust onder dato 6„' Janu: 1733.; Van\t[0.00017416155606042594, 0.9996156692504883, 0.00019040888582821935, 1.9734194211196154e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0338.jpg\tSumatras West Cust onder dato 6„en Janu: 1733.; Va\t[0.00014997494872659445, 0.9996034502983093, 0.0002290883130626753, 1.7510310499346815e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0339.jpg\tSumatras West Cust onder dato 6:„' Janu: 1733.; Va\t[0.00015520972374361008, 0.999599277973175, 0.000226766976993531, 1.86873585334979e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0340.jpg\tSumatras West Cust onder dato 6„e Janu: 1733; Jan;\t[0.00016408860392402858, 0.9994986057281494, 0.00031405669869855046, 2.3187751139630564e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_8526_0341.jpg\tVan Sumatras West Cust onder dato 6„' Janu: 1733. \t[0.00024603927158750594, 0.9982004165649414, 0.0015237010084092617, 2.9885608455515467e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_8526_0342.jpg\tVan Sumatras West Cust onder dato 6:' Janu: 1733.;\t[3.65465457434766e-05, 0.00017136383394245058, 0.9997891783714294, 2.919478674812126e-06]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0097.jpg\t\t[0.00014143031148705631, 0.0004445765516720712, 6.379372644005343e-05, 0.9993501305580139]\n",
+      "OUT\tOUT\tNL-HaNA_1.04.02_1547_0098.jpg\t\t[4.85044984088745e-05, 9.459190187044442e-05, 2.840567503881175e-05, 0.9998284578323364]\n",
+      "BEGIN\tBEGIN\tNL-HaNA_1.04.02_1547_0099.jpg\tuwe; Hoog Edele agtb: gebiedende Heere en Heeren; \t[0.999704897403717, 6.684372783638537e-05, 5.05169591633603e-05, 0.00017773527360986918]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0100.jpg\theen mne  dn d n n lel een w en de e sou co  an d;\t[0.009955938905477524, 0.9830584526062012, 0.0019515547901391983, 0.005034026224166155]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0101.jpg\tte Nambedle, den prince Cartadavile, en Moerianato\t[0.0023527953308075666, 0.9963956475257874, 0.0008378520724363625, 0.00041376808076165617]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0102.jpg\twerden; war op de ehien anmandijn lae telkens tot \t[0.0003756204969249666, 0.9992185831069946, 0.0003528220986481756, 5.297909228829667e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0103.jpg\t41; Mallabaar soude konnen doen, waarop sijnEe zal\t[0.0001735622645355761, 0.9995514750480652, 0.0002454735804349184, 2.9413024094537832e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0104.jpg\top Cochim benrogener aalewinsten des heevd Cochim \t[0.0001666918396949768, 0.9994947910308838, 0.0003111381665803492, 2.7394640710554086e-05]\n",
+      "IN\tIN\tNL-HaNA_1.04.02_1547_0105.jpg\t42; moerlikeden raelde den presenten desolaaten to\t[0.0002468328457325697, 0.9964441657066345, 0.0032622478902339935, 4.6766210289206356e-05]\n",
+      "END\tEND\tNL-HaNA_1.04.02_1547_0106.jpg\tgemerktaan dienkant moogelijk meerder vertier van \t[3.858864147332497e-05, 0.0002105794701492414, 0.9997467398643494, 4.100657406524988e-06]\n"
      ]
     },
     {
@@ -1233,7 +1203,7 @@
     "f1_score = MulticlassF1Score(average=None, num_classes=len(Label))\n",
     "\n",
     "for batch in tqdm(\n",
-    "    test_data.batches(BATCH_SIZE), total=len(test_data) / BATCH_SIZE, unit=\"batch\"\n",
+    "    test_data.batches(BATCH_SIZE), total=test_data.n_batches(BATCH_SIZE), unit=\"batch\"\n",
     "):\n",
     "    predicted = tagger(batch)\n",
     "    labels = batch.labels()\n",
@@ -1246,7 +1216,6 @@
     "\n",
     "    for page, pred, label in zip(batch.pages, predicted, labels):\n",
     "        pred_label = Label(pred.argmax().item())\n",
-    "        # if pred_label != Label.IN or label != Label.IN:\n",
     "        writer.writerow(\n",
     "            {\n",
     "                \"Predicted\": pred_label.name,\n",
@@ -1260,7 +1229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1268,10 +1237,10 @@
      "output_type": "stream",
      "text": [
       "Metric\tBEGIN\tIN\tEND\tOUT\n",
-      "MulticlassPrecision\t0.8400\t0.9968\t0.8571\t0.7500\n",
-      "MulticlassRecall\t1.0000\t0.9715\t0.9474\t1.0000\n",
-      "MulticlassF1Score\t0.9130\t0.9840\t0.9000\t0.8571\n",
-      "Accuracy (micro average):\t0.9724\n"
+      "MulticlassPrecision\t0.7308\t1.0000\t0.8696\t0.7368\n",
+      "MulticlassRecall\t0.9048\t0.9748\t0.9524\t1.0000\n",
+      "MulticlassF1Score\t0.8085\t0.9872\t0.9091\t0.8485\n",
+      "Accuracy (micro average):\t0.9718\n"
      ]
     }
    ],

--- a/tests/pagexml/test_dataset.py
+++ b/tests/pagexml/test_dataset.py
@@ -67,6 +67,47 @@ class TestLabel:
 
 
 class TestPageDataset:
+    @staticmethod
+    def page(doc_id):
+        return Page(label=Label.BEGIN, regions=[], scan_nr=1, doc_id=doc_id)
+
+    @pytest.mark.parametrize(
+        "dataset,batch_size,expected",
+        [
+            (
+                PageDataset([page("test doc 1")] * 2),
+                2,
+                [PageDataset([page("test doc 1")] * 2)],
+            ),
+            (
+                PageDataset([page("test doc 1")] * 4),
+                2,
+                [
+                    PageDataset([page("test doc 1")] * 2),
+                    PageDataset([page("test doc 1")] * 2),
+                ],
+            ),
+            (
+                PageDataset([page("test doc 1"), page("test doc 2")]),
+                1,
+                [PageDataset([page("test doc 1")]), PageDataset([page("test doc 2")])],
+            ),
+            (
+                PageDataset(
+                    [page("test doc 1"), page("test doc 1"), page("test doc 2")]
+                ),
+                4,
+                [
+                    PageDataset(
+                        [page("test doc 1"), page("test doc 1"), page("test doc 2")]
+                    )
+                ],
+            ),
+        ],
+    )
+    def test_batches(self, dataset, batch_size, expected):
+        assert list(dataset.batches(batch_size)) == expected
+
     @pytest.mark.parametrize(
         "pages, expected",
         [

--- a/tests/pagexml/test_dataset.py
+++ b/tests/pagexml/test_dataset.py
@@ -52,9 +52,9 @@ REGION3 = Region.model_validate(
 )
 
 
-def page(doc_id: str = "test doc"):
+def page(scan_nr: int = 1, doc_id: str = "test doc"):
     """Create a page with the given document ID."""
-    return Page(label=Label.BEGIN, regions=[], scan_nr=1, doc_id=doc_id)
+    return Page(label=Label.BEGIN, regions=[], scan_nr=scan_nr, doc_id=doc_id)
 
 
 class TestLabel:
@@ -119,31 +119,42 @@ class TestPageDataset:
         "dataset,batch_size,expected",
         [
             (
-                PageDataset([page("test doc 1")] * 2),
+                PageDataset([page(doc_id="test doc 1")] * 2),
                 2,
-                [PageDataset([page("test doc 1")] * 2)],
+                [PageDataset([page(doc_id="test doc 1")] * 2)],
             ),
             (
-                PageDataset([page("test doc 1")] * 4),
+                PageDataset([page(doc_id="test doc 1")] * 4),
                 2,
                 [
-                    PageDataset([page("test doc 1")] * 2),
-                    PageDataset([page("test doc 1")] * 2),
+                    PageDataset([page(doc_id="test doc 1")] * 2),
+                    PageDataset([page(doc_id="test doc 1")] * 2),
                 ],
             ),
             (
-                PageDataset([page("test doc 1"), page("test doc 2")]),
+                PageDataset([page(doc_id="test doc 1"), page(doc_id="test doc 2")]),
                 1,
-                [PageDataset([page("test doc 1")]), PageDataset([page("test doc 2")])],
+                [
+                    PageDataset([page(doc_id="test doc 1")]),
+                    PageDataset([page(doc_id="test doc 2")]),
+                ],
             ),
             (
                 PageDataset(
-                    [page("test doc 1"), page("test doc 1"), page("test doc 2")]
+                    [
+                        page(doc_id="test doc 1"),
+                        page(doc_id="test doc 1"),
+                        page(doc_id="test doc 2"),
+                    ]
                 ),
                 4,
                 [
                     PageDataset(
-                        [page("test doc 1"), page("test doc 1"), page("test doc 2")]
+                        [
+                            page(doc_id="test doc 1"),
+                            page(doc_id="test doc 1"),
+                            page(doc_id="test doc 2"),
+                        ]
                     )
                 ],
             ),

--- a/tests/pagexml/test_dataset.py
+++ b/tests/pagexml/test_dataset.py
@@ -89,6 +89,30 @@ class TestDocumentDataset:
     def test_n_batches(self, dataset, batch_size, expected):
         assert dataset.n_batches(batch_size) == expected
 
+    @pytest.mark.parametrize(
+        "dataset,portion,expected_training,expected_test",
+        [
+            (DocumentDataset([]), 0.8, DocumentDataset([]), DocumentDataset([])),
+            (
+                DocumentDataset([page()] * 10),
+                0.8,
+                DocumentDataset([page()] * 8),
+                DocumentDataset([page()] * 2),
+            ),
+            (
+                DocumentDataset([page()] * 9),
+                0.8,
+                DocumentDataset([page()] * 7),
+                DocumentDataset([page()] * 2),
+            ),
+        ],
+    )
+    def test_split(self, dataset, portion, expected_training, expected_test):
+        training, test = dataset.split(portion)
+
+        assert training == expected_training, "Training dataset is not as expected"
+        assert test == expected_test, "Test dataset is not as expected"
+
 
 class TestPageDataset:
     @pytest.mark.parametrize(

--- a/tests/pagexml/test_dataset.py
+++ b/tests/pagexml/test_dataset.py
@@ -48,6 +48,11 @@ REGION3 = Region.model_validate(
 )
 
 
+def page(doc_id):
+    """Create a page with the given document ID."""
+    return Page(label=Label.BEGIN, regions=[], scan_nr=1, doc_id=doc_id)
+
+
 class TestLabel:
     @pytest.mark.parametrize(
         "scores,expected,expected_exception",
@@ -67,10 +72,6 @@ class TestLabel:
 
 
 class TestPageDataset:
-    @staticmethod
-    def page(doc_id):
-        return Page(label=Label.BEGIN, regions=[], scan_nr=1, doc_id=doc_id)
-
     @pytest.mark.parametrize(
         "dataset,batch_size,expected",
         [


### PR DESCRIPTION
Implement `DocumentDataset` class that holds a list of `PageDataset` instances.
This allows the dataset can be shuffled and segmented without mixing up the order of the page sequences across documents.

Closes #11 