### PR TITLE
Fix 'package-ecosystem' for Poetry.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "poetry" # See documentation for possible values
+  - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Error message in https://github.com/LAHTeR/document_segmentation/network/updates:
```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/package-ecosystem' value "poetry" did not match one of the following values: npm, bundler, composer, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform, pub, swift

Please update the config file to conform with Dependabot's specification.
```

According to the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem), the correct value for Poetry should be `pip` instead of `poetry`.