### PR TITLE
Log nan loss

### DIFF
--- a/document_segmentation/model/page_sequence_tagger.py
+++ b/document_segmentation/model/page_sequence_tagger.py
@@ -199,6 +199,8 @@ class PageSequenceTagger(nn.Module, DeviceModule):
                 outputs = self(inventory.pages).to(self._device)
 
                 loss = criterion(outputs, inventory.label_tensor().to(self._device))
+                if torch.isnan(loss):
+                    logging.error(f"Loss is NaN for inventory: '{inventory}'")
 
                 loss.backward()
                 optimizer.step()


### PR DESCRIPTION
In [this run](https://wandb.ai/carschno/PageSequenceTagger/runs/xhf56pmf/workspace?nw=nwusercarschno), the loss was `nan`. Logging those cases for debugging.
